### PR TITLE
 polysyn: add optional USB MIDI host

### DIFF
--- a/gateware/src/rs/hal/src/polysynth.rs
+++ b/gateware/src/rs/hal/src/polysynth.rs
@@ -73,8 +73,10 @@ macro_rules! impl_polysynth {
                     self.registers.midi_read().read().bits()
                 }
 
-                pub fn usb_midi_host(&mut self, enable: bool)  {
+                pub fn usb_midi_host(&mut self, enable: bool, cfg_id: u8, endpt_id: u8)  {
                     self.registers.usb_midi_host().write(|w| unsafe { w.host().bit(enable) } );
+                    self.registers.usb_midi_cfg().write(|w| unsafe { w.value().bits(cfg_id) } );
+                    self.registers.usb_midi_endp().write(|w| unsafe { w.value().bits(endpt_id) } );
                 }
             }
         )+

--- a/gateware/src/rs/hal/src/polysynth.rs
+++ b/gateware/src/rs/hal/src/polysynth.rs
@@ -72,6 +72,10 @@ macro_rules! impl_polysynth {
                 pub fn midi_read(&mut self) -> u32  {
                     self.registers.midi_read().read().bits()
                 }
+
+                pub fn usb_midi_host(&mut self, enable: bool)  {
+                    self.registers.usb_midi_host().write(|w| unsafe { w.host().bit(enable) } );
+                }
             }
         )+
     };

--- a/gateware/src/top/polysyn/fw/src/main.rs
+++ b/gateware/src/top/polysyn/fw/src/main.rs
@@ -107,7 +107,9 @@ fn timer0_handler(app: &Mutex<RefCell<App>>) {
             }
         }
 
-        app.synth.usb_midi_host(opts.poly.usb_host.value == UsbHost::On);
+        app.synth.usb_midi_host(opts.usb.host.value == UsbHost::Enable,
+                                opts.usb.cfg_id.value,
+                                opts.usb.endpt_id.value);
     });
 }
 

--- a/gateware/src/top/polysyn/fw/src/main.rs
+++ b/gateware/src/top/polysyn/fw/src/main.rs
@@ -23,6 +23,7 @@ use tiliqua_lib::midi::MidiTouchController;
 use tiliqua_lib::generated_constants::*;
 use tiliqua_fw::*;
 use tiliqua_fw::opts::TouchControl;
+use tiliqua_fw::opts::UsbHost;
 use tiliqua_fw::opts::Screen;
 
 use embedded_graphics::{
@@ -87,7 +88,7 @@ fn timer0_handler(app: &Mutex<RefCell<App>>) {
 
 
         // Touch controller logic (sends MIDI to internal polysynth)
-        if opts.poly.interface.value == TouchControl::On {
+        if opts.poly.touch_control.value == TouchControl::On {
             app.ui.touch_led_mask(0b00111111);
             let touch = app.ui.pmod.touch();
             let jack = app.ui.pmod.jack();
@@ -106,6 +107,7 @@ fn timer0_handler(app: &Mutex<RefCell<App>>) {
             }
         }
 
+        app.synth.usb_midi_host(opts.poly.usb_host.value == UsbHost::On);
     });
 }
 

--- a/gateware/src/top/polysyn/fw/src/opts.rs
+++ b/gateware/src/top/polysyn/fw/src/opts.rs
@@ -16,6 +16,7 @@ pub enum Screen {
     Poly,
     Beam,
     Vector,
+    Usb,
 }
 
 #[derive(Clone, Copy, PartialEq, EnumIter, IntoStaticStr)]
@@ -29,7 +30,7 @@ pub enum TouchControl {
 #[strum(serialize_all = "kebab-case")]
 pub enum UsbHost {
     Off,
-    On,
+    Enable,
 }
 
 #[derive(Clone)]
@@ -45,7 +46,6 @@ impl_option_view!(HelpOptions,
 pub struct PolyOptions {
     pub selected: Option<usize>,
     pub touch_control: EnumOption<TouchControl>,
-    pub usb_host: EnumOption<UsbHost>,
     pub drive: NumOption<u16>,
     pub reso: NumOption<u16>,
     pub diffuse: NumOption<u16>,
@@ -53,7 +53,6 @@ pub struct PolyOptions {
 
 impl_option_view!(PolyOptions,
                   touch_control,
-                  usb_host,
                   drive,
                   reso,
                   diffuse);
@@ -82,6 +81,17 @@ impl_option_view!(BeamOptions,
                   persist, decay, intensity, hue, palette);
 
 #[derive(Clone)]
+pub struct UsbOptions {
+    pub selected: Option<usize>,
+    pub host: EnumOption<UsbHost>,
+    pub cfg_id: NumOption<u8>,
+    pub endpt_id: NumOption<u8>,
+}
+
+impl_option_view!(UsbOptions,
+                  host, cfg_id, endpt_id);
+
+#[derive(Clone)]
 pub struct Options {
     pub modify: bool,
     pub draw: bool,
@@ -91,13 +101,15 @@ pub struct Options {
     pub poly:   PolyOptions,
     pub beam:   BeamOptions,
     pub vector: VectorOptions,
+    pub usb: UsbOptions,
 }
 
 impl_option_page!(Options,
                   (Screen::Help,   help),
                   (Screen::Poly,   poly),
                   (Screen::Beam,   beam),
-                  (Screen::Vector, vector));
+                  (Screen::Vector, vector),
+                  (Screen::Usb,    usb));
 
 impl Options {
     pub fn new() -> Options {
@@ -123,10 +135,6 @@ impl Options {
                 touch_control: EnumOption{
                     name: String::from_str("touch").unwrap(),
                     value: TouchControl::On,
-                },
-                usb_host: EnumOption{
-                    name: String::from_str("usb-host").unwrap(),
-                    value: UsbHost::Off,
                 },
                 drive: NumOption{
                     name: String::from_str("overdrive").unwrap(),
@@ -202,6 +210,27 @@ impl Options {
                     max: 15,
                 },
             },
+            usb: UsbOptions {
+                selected: None,
+                host: EnumOption{
+                    name: String::from_str("host").unwrap(),
+                    value: UsbHost::Off,
+                },
+                cfg_id: NumOption{
+                    name: String::from_str("cfg-id").unwrap(),
+                    value: 1,
+                    step: 1,
+                    min: 1,
+                    max: 15,
+                },
+                endpt_id: NumOption{
+                    name: String::from_str("endpt-id").unwrap(),
+                    value: 2,
+                    step: 1,
+                    min: 1,
+                    max: 15,
+                },
+            }
         }
     }
 }

--- a/gateware/src/top/polysyn/fw/src/opts.rs
+++ b/gateware/src/top/polysyn/fw/src/opts.rs
@@ -21,8 +21,15 @@ pub enum Screen {
 #[derive(Clone, Copy, PartialEq, EnumIter, IntoStaticStr)]
 #[strum(serialize_all = "kebab-case")]
 pub enum TouchControl {
-    On,
     Off,
+    On,
+}
+
+#[derive(Clone, Copy, PartialEq, EnumIter, IntoStaticStr)]
+#[strum(serialize_all = "kebab-case")]
+pub enum UsbHost {
+    Off,
+    On,
 }
 
 #[derive(Clone)]
@@ -37,14 +44,16 @@ impl_option_view!(HelpOptions,
 #[derive(Clone)]
 pub struct PolyOptions {
     pub selected: Option<usize>,
-    pub interface: EnumOption<TouchControl>,
-    pub drive:     NumOption<u16>,
-    pub reso:      NumOption<u16>,
-    pub diffuse:   NumOption<u16>,
+    pub touch_control: EnumOption<TouchControl>,
+    pub usb_host: EnumOption<UsbHost>,
+    pub drive: NumOption<u16>,
+    pub reso: NumOption<u16>,
+    pub diffuse: NumOption<u16>,
 }
 
 impl_option_view!(PolyOptions,
-                  interface,
+                  touch_control,
+                  usb_host,
                   drive,
                   reso,
                   diffuse);
@@ -111,9 +120,13 @@ impl Options {
             },
             poly: PolyOptions {
                 selected: None,
-                interface: EnumOption{
+                touch_control: EnumOption{
                     name: String::from_str("touch").unwrap(),
                     value: TouchControl::On,
+                },
+                usb_host: EnumOption{
+                    name: String::from_str("usb-host").unwrap(),
+                    value: UsbHost::Off,
                 },
                 drive: NumOption{
                     name: String::from_str("overdrive").unwrap(),

--- a/gateware/src/top/polysyn/top.py
+++ b/gateware/src/top/polysyn/top.py
@@ -44,6 +44,7 @@ from tiliqua.delay_line        import DelayLine
 from tiliqua.eurorack_pmod     import ASQ
 from tiliqua.tiliqua_soc       import TiliquaSoc
 from tiliqua.cli               import top_level_cli
+from tiliqua.usb_host          import SimpleUSBMIDIHost
 
 class Diffuser(wiring.Component):
 
@@ -258,6 +259,10 @@ class SynthPeripheral(wiring.Component):
     class MidiRead(csr.Register, access="r"):
         msg: csr.Field(csr.action.R, unsigned(32))
 
+    class UsbMidiHost(csr.Register, access="w"):
+        """1 enables USB MIDI host."""
+        host: csr.Field(csr.action.W, unsigned(1))
+
     def __init__(self, synth=None):
         self.synth = synth
         regs = csr.Builder(addr_width=7, data_width=8)
@@ -270,10 +275,12 @@ class SynthPeripheral(wiring.Component):
         self._matrix_busy   = regs.add("matrix_busy",   self.MatrixBusy(),   offset=voices_csr_end + 0x4)
         self._midi_write    = regs.add("midi_write",    self.MidiWrite(),    offset=voices_csr_end + 0x8)
         self._midi_read     = regs.add("midi_read",     self.MidiRead(),     offset=voices_csr_end + 0xC)
+        self._midi_host     = regs.add("usb_midi_host", self.UsbMidiHost(),  offset=voices_csr_end + 0x10)
         self._bridge = csr.Bridge(regs.as_memory_map())
         super().__init__({
             "bus": In(csr.Signature(addr_width=regs.addr_width, data_width=regs.data_width)),
-            "i_midi": In(stream.Signature(midi.MidiMessage))
+            "i_midi": In(stream.Signature(midi.MidiMessage)),
+            "usb_midi_host": Out(1),
         })
         self.bus.memory_map = self._bridge.bus.memory_map
 
@@ -287,6 +294,10 @@ class SynthPeripheral(wiring.Component):
             m.d.sync += self.synth.drive.eq(self._drive.f.value.w_data)
         with m.If(self._reso.f.value.w_stb):
             m.d.sync += self.synth.reso.eq(self._reso.f.value.w_data)
+
+        # enable USB MIDI host
+        with m.If(self._midi_host.f.host.w_stb):
+            m.d.sync += self.usb_midi_host.eq(self._midi_host.f.host.w_data)
 
         # voice tracking
         for i, voice in enumerate(self._voices):
@@ -312,7 +323,6 @@ class SynthPeripheral(wiring.Component):
                 matrix_busy.eq(0),
                 self.synth.diffuser.matrix.c.valid.eq(0),
             ]
-
 
         # MIDI injection and arbiter between SoC MIDI and HW MIDI -> synth MIDI.
         m.submodules.soc_midi_fifo = soc_midi_fifo = SyncFIFOBuffered(
@@ -396,13 +406,33 @@ class PolySoc(TiliquaSoc):
         m.submodules.astream = astream = eurorack_pmod.AudioStream(pmod0)
 
         if sim.is_hw(platform):
-            # polysynth midi
+            # Polysynth hardware MIDI sources
+
+            # TRS MIDI (serial)
             midi_pins = platform.request("midi")
             m.submodules.serialrx = serialrx = midi.SerialRx(
                     system_clk_hz=60e6, pins=midi_pins)
-            m.submodules.midi_decode = midi_decode = midi.MidiDecode()
-            wiring.connect(m, serialrx.o, midi_decode.i)
-            wiring.connect(m, midi_decode.o, self.synth_periph.i_midi)
+            m.submodules.midi_decode_trs = midi_decode_trs = midi.MidiDecode()
+            wiring.connect(m, serialrx.o, midi_decode_trs.i)
+
+            # USB MIDI host (experimental)
+            ulpi = platform.request(platform.default_usb_connection)
+            m.submodules.usb = usb = SimpleUSBMIDIHost(
+                    bus=ulpi,
+                    hardcoded_configuration_id=1,
+                    hardcoded_midi_endpoint=2,
+            )
+            m.submodules.midi_decode_usb = midi_decode_usb = midi.MidiDecode(usb=True)
+            wiring.connect(m, usb.o_midi_bytes, midi_decode_usb.i)
+
+            # Only enable VBUS if MIDI HOST is enabled.
+            vbus_o = platform.request("usb_vbus_en").o
+            with m.If(self.synth_periph.usb_midi_host):
+                wiring.connect(m, midi_decode_usb.o, self.synth_periph.i_midi)
+                m.d.comb += vbus_o.eq(1)
+            with m.Else():
+                wiring.connect(m, midi_decode_trs.o, self.synth_periph.i_midi)
+                m.d.comb += vbus_o.eq(0)
 
         # polysynth audio
         wiring.connect(m, astream.istream, polysynth.i)


### PR DESCRIPTION
- Add USB screen to `polysyn` menu for enabling MIDI HOST (disconnects TRS MIDI if enabled)
- Correct config ID and endpoint ID can be set in menu, but must currently be manually checked (and set) by looking at the USB device descriptor (e.g. using `lsusb`).