### PR TITLE
bootloader/flash: add 'status' command for dumping manifest status

### DIFF
--- a/gateware/docs/bootloader.rst
+++ b/gateware/docs/bootloader.rst
@@ -29,7 +29,7 @@ First-time setup
 
     # Flash bootloader to start of flash, build assuming XIP (execute directly from SPI flash, not PSRAM)
     pdm bootloader build --fw-location=spiflash --resolution 1280x720p60
-    pdm flash build/bootloader-*.tar.gz
+    pdm flash archive build/bootloader-*.tar.gz
 
 3. DISCONNECT USB DBG port, reboot Tiliqua.
 

--- a/gateware/docs/gettingstarted.rst
+++ b/gateware/docs/gettingstarted.rst
@@ -55,9 +55,10 @@ Such archives may be flashed as follows:
 
 .. code-block:: bash
 
-   # Flash user bitstreams to slots 1-7
-   pdm flash build/selftest-*.tar.gz --slot 1
-   pdm flash build/xbeam-*.tar.gz --slot 2
+   # Flash user bitstreams to the desired slot (0-7)
+   pdm flash archive build/selftest-*.tar.gz --slot 1
+   pdm flash archive build/xbeam-*.tar.gz --slot 2
+   pdm flash status # check what is on the Tiliqua
 
 If you are running an SoC, you can monitor serial output like so:
 


### PR DESCRIPTION
- Modify `pdm flash` command to have `archive` and `status` subcommands.
- Now, `pdm flash archive <bitstream.tar.gz>` is used for flashing bitstreams to Tiliqua slots.
- A new `pdm flash status` command is added for dumping the contents of each manifest in every slot (to see what's currently programmed to the Tiliqua).
- An example execution:

![Screenshot_select-area_20250118194250](https://github.com/user-attachments/assets/78a6892a-05bd-4b71-8f17-4ca81e5c1843)
