### PR TITLE
hw/r4: add `TiliquaR4Mobo` pinouts and R3/R4 changelist

### DIFF
--- a/gateware/docs/technical.rst
+++ b/gateware/docs/technical.rst
@@ -29,7 +29,7 @@ Embedded FPGA SoM (`soldiercrab`)
 
 **Repository:** `soldiercrab <https://github.com/apfaudio/soldiercrab>`_
 
-- Lattice ECP5 (25 K) FPGA, supported by open-source FPGA toolchains
+- Lattice ECP5 FPGA, supported by open-source FPGA toolchains
 - 256 Mbit (32 MByte) HyperRAM / oSPI RAM (for long audio buffers or video framebuffers)
 - 128 Mbit (16 MByte) SPI flash for user bitstreams
 - High-speed USB HS PHY (ULPI)
@@ -43,3 +43,52 @@ Audio Interface
 - Touch and proximity sensing on all 8 audio jacks (if unused)
 - PWM-controlled, user-programmable red/green LEDs on each audio channel
 - Jack insertion detection on all 8 jacks
+
+Hardware Revisions
+------------------
+
+There are a few Tiliqua hardware variants in existence:
+
+- **Tiliqua R2**
+    - **SoldierCrab R2** FPGA SoM (LFE5U-45F, 3.3V 16MByte HyperRAM)
+    - **Tiliqua R2** motherboard and front panel.
+    - **eurorack-pmod R3.3** audio interface.
+- **Tiliqua R3**
+    - **SoldierCrab R3** FPGA SoM (LFE5U-25F, 1.8V 32MByte oSPIRAM)
+    - **Tiliqua R3** motherboard and front panel.
+    - **eurorack-pmod R3.3** audio interface.
+- **Tiliqua R4** (unreleased)
+
+Hardware Changelist
+^^^^^^^^^^^^^^^^^^^
+
+- From **Tiliqua R2** to **Tiliqua R3**:
+    - Pinswap all DVI pins to true ECP5 complementary pairs.
+    - Swap all tantalums for ceramics, clean up PSU routing, swap LDO for TPS7A91, add choke input capacitors
+    - Delete unused LEDs (MIDI bottom-side)
+    - Fix EDID +5V I2C bridge schematic and enable.
+    - Adjust fuses: +12V ingress 200mA->350mA fuse, GPDI +5V NONE->50mA fuse (so USB host doesn't pop the fuse!)
+    - Move encoder footprint 0.4mm in, midi 0.1mm out for 0.5mm shim washer on encoder
+    - Pinswap ex0 / ex1 / ffc connectors for improved routing and SI.
+    - Update LED current limiting resistors s/120R/220R
+    - Swap rp2040 xtal to ABM8/15pF/1K (improve yield)
+    - New M2.5 standoff footprint
+    - Move 12V ingress connector in 1.5mm so we can better fit in skiffs.
+    - Switch from 1.6mm to 1.2mm PCBA stackup for mechanical reasons (and improve usb2 connector yield)
+    - (panel) fix DVI connector cutout
+    - Add 2x spare pins for RP2040/ECP5 I2C (no pullups)
+    - Layerswap In1 / In2 (move GND closer to SMPS)
+    - Add flip-flop on CODEC PDN pin (allows for soft-mute when swapping bitstreams)
+- From **Tiliqua R3** to **Tiliqua R4**:
+    - Add external PLL SI5351 and route 2x clocks to ECP5 (useful for EMC as it supports spread-spectrum, also for runtime clock/resolution switching).
+    - Add series 27R/33R on all FFC lines to reduce radiated emissions.
+    - Pinswaps to ensure external PLL is routed to true ECP5 clock input pins:
+        - FFC_SDIN1: 44 -> 42
+        - ENC_B: 40 -> 12
+        - ENC_A: 42 -> 8
+        - PLL_CLK1 -> 40 (removed: spare FPGA to RP2040 line)
+        - PLL_CLK0 -> 44 (removed: spare FPGA to RP2040 line)
+    - Route 4 new ex0/ex1 pins to RP2040 spare pins (shared with expansion connectors)
+    - Swap RP2040 SPI flash for 128MBit part
+    - Put spare RP2040 I2C pins on main tiliqua-mobo I2C bus.
+    - Switch from 4L stackup to 6L stackup to improve SI/EMC.

--- a/gateware/src/tiliqua/cli.py
+++ b/gateware/src/tiliqua/cli.py
@@ -128,6 +128,8 @@ def top_level_cli(
                         help="platform override: Tiliqua R2 with a SoldierCrab R3")
     parser.add_argument('--hw3', action='store_true',
                         help="platform override: Tiliqua R3 with a SoldierCrab R3")
+    parser.add_argument('--hw4', action='store_true',
+                        help="platform override: Tiliqua R4 with a SoldierCrab R3")
     parser.add_argument('--bootaddr', type=str, default="0x0",
                         help="'bootaddr' argument of ecppack (default: 0x0).")
     parser.add_argument('--verbose', action='store_true',
@@ -196,7 +198,10 @@ def top_level_cli(
         else:
             args.brief = ""
 
-    if args.hw3:
+    if args.hw4:
+        # Tiliqua R4 with SoldierCrab R3
+        hw_platform = TiliquaR4SC3Platform()
+    elif args.hw3:
         # Tiliqua R3 with SoldierCrab R3
         hw_platform = TiliquaR3SC3Platform()
     else:
@@ -234,8 +239,7 @@ def top_level_cli(
         return manifest
 
     def create_bitstream_archive():
-        hwrev = "r3" if args.hw3 else "r2"
-        archive_name = f"{args.name.lower()}-{repo.head.object.hexsha[:6]}-{hwrev}.tar.gz"
+        archive_name = f"{args.name.lower()}-{repo.head.object.hexsha[:6]}-{hw_platform.brief}.tar.gz"
         archive_path = os.path.join(build_path, archive_name)
         bitstream_path = "build/top.bit"
         

--- a/gateware/src/tiliqua/tiliqua_platform.py
+++ b/gateware/src/tiliqua/tiliqua_platform.py
@@ -287,9 +287,90 @@ class _TiliquaR3Mobo:
         Connector("pmod", 1, "59 63 14 20 - - 61 15 13 22 - -", conn=("m2", 0)),
     ]
 
+class _TiliquaR4Mobo:
+    resources   = [
+        # External PLL (SI5351A) clock inputs.
+        Resource("expll_clk0", 0, Pins("44", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("expll_clk1", 0, Pins("40", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+
+        # Quadrature rotary encoder and switch. These are already debounced by an RC filter.
+        Resource("encoder", 0,
+                 Subsignal("i", PinsN("8", dir="i", conn=("m2", 0))),
+                 Subsignal("q", PinsN("12", dir="i", conn=("m2", 0))),
+                 Subsignal("s", PinsN("43", dir="i", conn=("m2", 0))),
+                 Attrs(IO_TYPE="LVCMOS33")),
+
+        # USB: 5V supply OUT enable (only touch this if you're sure you are a USB host!)
+        Resource("usb_vbus_en", 0, PinsN("32", dir="o", conn=("m2", 0)),
+                 Attrs(IO_TYPE="LVCMOS33")),
+
+        # USB: Interrupt line from TUSB322I
+        Resource("usb_int", 0, PinsN("47", dir="i", conn=("m2", 0)),
+                 Attrs(IO_TYPE="LVCMOS33")),
+
+        # Output enable for LEDs driven by PCA9635 on motherboard PCBA
+        Resource("mobo_leds_oe", 0, PinsN("11", dir="o", conn=("m2", 0))),
+
+        # DVI: Hotplug Detect
+        Resource("dvi_hpd", 0, Pins("37", dir="i", conn=("m2", 0)),
+                 Attrs(IO_TYPE="LVCMOS33")),
+
+        # TRS MIDI RX
+        Resource("midi", 0, Subsignal("rx", Pins("6", dir="i", conn=("m2", 0)),
+                                      Attrs(IO_TYPE="LVCMOS33"))),
+
+        # Motherboard PCBA I2C bus. Includes:
+        # - address 0x05: PCA9635 LED driver
+        # - address 0x47: TUSB322I USB-C controller
+        # - address 0x50: DVI EDID EEPROM (through 3V3 <-> 5V translator)
+        # - address 0x60: SI5351A external PLL
+        Resource("i2c", 0,
+            Subsignal("sda", Pins("51", dir="io", conn=("m2", 0))),
+            Subsignal("scl", Pins("53", dir="io", conn=("m2", 0))),
+        ),
+
+        # RP2040 UART bridge
+        UARTResource(0,
+            rx="19", tx="17", conn=("m2", 0),
+            attrs=Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")
+        ),
+
+        # FFC connector to eurorack-pmod on the back.
+        Resource("audio_ffc", 0,
+            Subsignal("sdin1",   Pins("42", dir="o",  conn=("m2", 0))),
+            Subsignal("sdout1",  Pins("46", dir="i",  conn=("m2", 0))),
+            Subsignal("lrck",    Pins("48", dir="o",  conn=("m2", 0))),
+            Subsignal("bick",    Pins("50", dir="o",  conn=("m2", 0))),
+            Subsignal("mclk",    Pins("67", dir="o",  conn=("m2", 0))),
+            Subsignal("pdn_d",   Pins("65", dir="o",  conn=("m2", 0))),
+            Subsignal("pdn_clk", Pins("56", dir="o",  conn=("m2", 0))),
+            Subsignal("i2c_sda", Pins("71", dir="io", conn=("m2", 0))),
+            Subsignal("i2c_scl", Pins("69", dir="io", conn=("m2", 0))),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        # DVI
+        # Note: technically DVI outputs are supposed to be open-drain, but
+        # compatibility with cheap AliExpress screens seems better with push/pull outputs.
+        Resource("dvi", 0,
+            Subsignal("d0", Pins("60", dir="o", conn=("m2", 0))),
+            Subsignal("d1", Pins("62", dir="o", conn=("m2", 0))),
+            Subsignal("d2", Pins("68", dir="o", conn=("m2", 0))),
+            Subsignal("ck", Pins("52", dir="o", conn=("m2", 0))),
+            Attrs(IO_TYPE="LVCMOS33D", DRIVE="8", SLEWRATE="FAST")
+         ),
+    ]
+
+    # Expansion connectors ex0 and ex1
+    connectors  = [
+        Connector("pmod", 0, "55 38 66 41 - - 57 35 34 70 - -", conn=("m2", 0)),
+        Connector("pmod", 1, "59 63 14 20 - - 61 15 13 22 - -", conn=("m2", 0)),
+    ]
+
 class TiliquaR2SC2Platform(SoldierCrabR2Platform, LUNAPlatform):
     name                   = ("Tiliqua R2 / SoldierCrab R2 "
                               f"({SoldierCrabR2Platform.device}/{SoldierCrabR2Platform.psram_id})")
+    brief                  = "r2"
     clock_domain_generator = tiliqua_pll.TiliquaDomainGenerator4PLLs
     default_usb_connection = "ulpi"
 
@@ -306,6 +387,7 @@ class TiliquaR2SC2Platform(SoldierCrabR2Platform, LUNAPlatform):
 class TiliquaR2SC3Platform(SoldierCrabR3Platform, LUNAPlatform):
     name                   = ("Tiliqua R2 / SoldierCrab R3 "
                               f"({SoldierCrabR3Platform.device}/{SoldierCrabR3Platform.psram_id})")
+    brief                  = "r2sc3"
     clock_domain_generator = tiliqua_pll.TiliquaDomainGenerator2PLLs
     default_usb_connection = "ulpi"
 
@@ -322,6 +404,7 @@ class TiliquaR2SC3Platform(SoldierCrabR3Platform, LUNAPlatform):
 class TiliquaR3SC3Platform(SoldierCrabR3Platform, LUNAPlatform):
     name                   = ("Tiliqua R3 / SoldierCrab R3 "
                               f"({SoldierCrabR3Platform.device}/{SoldierCrabR3Platform.psram_id})")
+    brief                  = "r3"
     clock_domain_generator = tiliqua_pll.TiliquaDomainGenerator2PLLs
     default_usb_connection = "ulpi"
 
@@ -333,6 +416,23 @@ class TiliquaR3SC3Platform(SoldierCrabR3Platform, LUNAPlatform):
     connectors = [
         *SoldierCrabR3Platform.connectors,
         *_TiliquaR3Mobo.connectors
+    ]
+
+class TiliquaR4SC3Platform(SoldierCrabR3Platform, LUNAPlatform):
+    name                   = ("Tiliqua R4 / SoldierCrab R3 "
+                              f"({SoldierCrabR3Platform.device}/{SoldierCrabR3Platform.psram_id})")
+    brief                  = "r4"
+    clock_domain_generator = tiliqua_pll.TiliquaDomainGenerator2PLLs
+    default_usb_connection = "ulpi"
+
+    resources = [
+        *SoldierCrabR3Platform.resources,
+        *_TiliquaR4Mobo.resources
+    ]
+
+    connectors = [
+        *SoldierCrabR3Platform.connectors,
+        *_TiliquaR4Mobo.connectors
     ]
 
 class RebootProvider(wiring.Component):


### PR DESCRIPTION
- Add pinouts for Tiliqua R4 motherboard with `--hw4` flag (no new features yet).
- Add R2/R3/R4 changelist to hardware documentation.