### PR TITLE
rs/ui: remove macro usage from ui::UI

### DIFF
--- a/gateware/src/rs/lib/src/ui.rs
+++ b/gateware/src/rs/lib/src/ui.rs
@@ -2,159 +2,159 @@
 // it on Tiliqua LEDs where appropriate, with fade-out
 // to automatic CV LEDs when nothing is touched for a bit.
 //
-// FIXME: does this really need to be a macro? (quickest
-// solution as it depends on a few types that are custom
-// to each example core).
 
-#[macro_export]
-macro_rules! impl_ui {
-    ($(
-        $UI: ident, $OPTIONS:ty,
-        $ENCODER:ty, $PCA9635:ty, $PMOD: ty
-    )+) => {
-        $(
-            pub struct $UI {
-                pub opts: $OPTIONS,
-                encoder: $ENCODER,
-                pca9635: $PCA9635,
-                pub pmod: $PMOD,
-                uptime_ms: u32,
-                time_since_encoder_touched: u32,
-                time_since_midi_activity: u32,
-                toggle_leds: bool,
-                period_ms: u32,
-                encoder_fade_ms: u32,
-                touch_led_mask: u8,
-            }
+use crate::opt::*;
+use crate::leds;
+use embedded_hal::i2c::I2c;
+use tiliqua_hal::encoder::Encoder;
+use tiliqua_hal::pmod::EurorackPmod;
+use tiliqua_hal::pca9635::{Pca9635Driver, Pca9635};
 
-            impl $UI {
-                pub fn new(opts: $OPTIONS, period_ms: u32, encoder: $ENCODER,
-                           pca9635: $PCA9635, pmod: $PMOD) -> Self {
-                    Self {
-                        opts,
-                        encoder,
-                        pca9635,
-                        pmod,
-                        uptime_ms: 0u32,
-                        time_since_encoder_touched: 0u32,
-                        time_since_midi_activity: 0u32,
-                        toggle_leds: false,
-                        period_ms,
-                        encoder_fade_ms: 1000u32,
-                        touch_led_mask: 0u8,
+pub struct UI<EncoderT, PmodT, MoboI2CT, OptionsT>
+where
+    EncoderT: Encoder,
+    PmodT: EurorackPmod,
+    MoboI2CT: I2c,
+    OptionsT: OptionPage + OptionPageEncoderInterface
+{
+    pub opts: OptionsT,
+    encoder: EncoderT,
+    pca9635: Pca9635Driver<MoboI2CT>,
+    pub pmod: PmodT,
+    uptime_ms: u32,
+    time_since_encoder_touched: u32,
+    time_since_midi_activity: u32,
+    toggle_leds: bool,
+    period_ms: u32,
+    encoder_fade_ms: u32,
+    touch_led_mask: u8,
+    draw: bool,
+}
+
+impl<EncoderT: Encoder,
+     PmodT: EurorackPmod,
+     MoboI2CT: I2c,
+     OptionsT: OptionPage + OptionPageEncoderInterface>
+         UI<EncoderT, PmodT, MoboI2CT, OptionsT> {
+    pub fn new(opts: OptionsT, period_ms: u32, encoder: EncoderT,
+               pca9635: Pca9635Driver<MoboI2CT>, pmod: PmodT) -> Self {
+        Self {
+            opts,
+            encoder,
+            pca9635,
+            pmod,
+            uptime_ms: 0u32,
+            time_since_encoder_touched: 0u32,
+            time_since_midi_activity: 0u32,
+            toggle_leds: false,
+            period_ms,
+            encoder_fade_ms: 1000u32,
+            touch_led_mask: 0u8,
+            draw: true
+        }
+    }
+
+    pub fn midi_activity(&mut self) {
+        self.time_since_midi_activity = 0;
+    }
+
+    pub fn touch_led_mask(&mut self, mask: u8) {
+        self.touch_led_mask = mask;
+    }
+
+    pub fn update(&mut self) {
+        //
+        // Consume encoder, update options
+        //
+
+        self.encoder.update();
+
+        self.time_since_encoder_touched += self.period_ms;
+        self.time_since_midi_activity += self.period_ms;
+        self.uptime_ms += self.period_ms;
+
+        let ticks = self.encoder.poke_ticks();
+        if ticks != 0 {
+            self.opts.consume_ticks(ticks);
+            self.time_since_encoder_touched = 0;
+        }
+        if self.encoder.poke_btn() {
+            self.opts.toggle_modify();
+            self.time_since_encoder_touched = 0;
+        }
+
+        //
+        // Update LEDs
+        //
+
+        if self.uptime_ms % (20*self.period_ms) == 0 {
+            self.toggle_leds = !self.toggle_leds;
+        }
+
+
+        for n in 0..16 {
+            self.pca9635.leds[n] = 0u8;
+        }
+
+        leds::mobo_pca9635_set_bargraph(&self.opts, &mut self.pca9635.leds,
+                                        self.toggle_leds);
+
+        if self.time_since_midi_activity < 100 {
+            leds::mobo_pca9635_set_midi(&mut self.pca9635.leds, 0xff, 0xff);
+        } else {
+            leds::mobo_pca9635_set_midi(&mut self.pca9635.leds, 0x0, 0x0);
+        }
+
+        if self.opts.modify() {
+            // Flashing if we're modifying something
+            self.pmod.led_all_auto();
+            if self.toggle_leds {
+                if let Some(n) = self.opts.view().selected() {
+                    // red for option selection
+                    if n < 8 {
+                        self.pmod.led_set_manual(n, i8::MAX);
                     }
-                }
-
-                pub fn midi_activity(&mut self) {
-                    self.time_since_midi_activity = 0;
-                }
-
-                pub fn touch_led_mask(&mut self, mask: u8) {
-                    self.touch_led_mask = mask;
-                }
-
-                pub fn update(&mut self) {
-                    use tiliqua_lib::opt::*;
-                    use tiliqua_hal::pmod::EurorackPmod;
-                    use tiliqua_hal::encoder::Encoder;
-                    use tiliqua_hal::pca9635::Pca9635;
-
-                    //
-                    // Consume encoder, update options
-                    //
-
-                    self.encoder.update();
-
-                    self.time_since_encoder_touched += self.period_ms;
-                    self.time_since_midi_activity += self.period_ms;
-                    self.uptime_ms += self.period_ms;
-
-                    let ticks = self.encoder.poke_ticks();
-                    if ticks != 0 {
-                        self.opts.consume_ticks(ticks);
-                        self.time_since_encoder_touched = 0;
+                } else {
+                    // green for screen selection
+                    let n = (self.opts.screen().percent() * (self.opts.screen().n_unique_values() as f32)) as usize;
+                    if n < 8 {
+                        self.pmod.led_set_manual(n, i8::MIN);
                     }
-                    if self.encoder.poke_btn() {
-                        self.opts.toggle_modify();
-                        self.time_since_encoder_touched = 0;
-                    }
-
-                    //
-                    // Update LEDs
-                    //
-
-                    if self.uptime_ms % (20*self.period_ms) == 0 {
-                        self.toggle_leds = !self.toggle_leds;
-                    }
-
-
-                    for n in 0..16 {
-                        self.pca9635.leds[n] = 0u8;
-                    }
-
-                    leds::mobo_pca9635_set_bargraph(&self.opts, &mut self.pca9635.leds,
-                                                    self.toggle_leds);
-
-                    if self.time_since_midi_activity < 100 {
-                        leds::mobo_pca9635_set_midi(&mut self.pca9635.leds, 0xff, 0xff);
-                    } else {
-                        leds::mobo_pca9635_set_midi(&mut self.pca9635.leds, 0x0, 0x0);
-                    }
-
-                    if self.opts.modify() {
-                        // Flashing if we're modifying something
-                        self.pmod.led_all_auto();
-                        if self.toggle_leds {
-                            if let Some(n) = self.opts.view().selected() {
-                                // red for option selection
-                                if n < 8 {
-                                    self.pmod.led_set_manual(n, i8::MAX);
-                                }
-                            } else {
-                                // green for screen selection
-                                let n = (self.opts.screen.percent() * (self.opts.screen.n_unique_values() as f32)) as usize;
-                                if n < 8 {
-                                    self.pmod.led_set_manual(n, i8::MIN);
-                                }
-                            }
-                        }
-                    } else {
-                        // Not flashing with fade-out if we stopped modifying something
-                        if self.time_since_encoder_touched < self.encoder_fade_ms {
-                            for n in 0..8 {
-                                self.pmod.led_set_manual(n, 0i8);
-                            }
-                            let fade: i8 = (((self.encoder_fade_ms-self.time_since_encoder_touched) * 120) /
-                                             self.encoder_fade_ms) as i8;
-                            if let Some(n) = self.opts.view().selected() {
-                                // red for option selection
-                                if n < 8 {
-                                    self.pmod.led_set_manual(n, fade);
-                                }
-                            } else {
-                                // green for screen selection
-                                self.pmod.led_set_manual(0, -fade);
-                            }
-                        } else {
-                            self.pmod.led_all_auto();
-                            // Override LEDs with touch value if no jack inserted.
-                            let touch = self.pmod.touch();
-                            for n in 0..8 {
-                                if (self.pmod.jack() & (1<<n)) == 0 {
-                                    if (self.touch_led_mask & (1<<n)) != 0 {
-                                        self.pmod.led_set_manual(n,(touch[n]>>2) as i8);
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    self.pca9635.push().ok();
-
-                    self.opts.draw = self.time_since_encoder_touched < self.encoder_fade_ms ||
-                                     self.opts.modify();
                 }
             }
-        )+
+        } else {
+            // Not flashing with fade-out if we stopped modifying something
+            if self.time_since_encoder_touched < self.encoder_fade_ms {
+                for n in 0..8 {
+                    self.pmod.led_set_manual(n, 0i8);
+                }
+                let fade: i8 = (((self.encoder_fade_ms-self.time_since_encoder_touched) * 120) /
+                                 self.encoder_fade_ms) as i8;
+                if let Some(n) = self.opts.view().selected() {
+                    // red for option selection
+                    if n < 8 {
+                        self.pmod.led_set_manual(n, fade);
+                    }
+                } else {
+                    // green for screen selection
+                    self.pmod.led_set_manual(0, -fade);
+                }
+            } else {
+                self.pmod.led_all_auto();
+                // Override LEDs with touch value if no jack inserted.
+                let touch = self.pmod.touch();
+                for n in 0..8 {
+                    if (self.pmod.jack() & (1<<n)) == 0 {
+                        if (self.touch_led_mask & (1<<n)) != 0 {
+                            self.pmod.led_set_manual(n,(touch[n]>>2) as i8);
+                        }
+                    }
+                }
+            }
+        }
+
+        self.pca9635.push().ok();
+
+        self.draw = self.time_since_encoder_touched < self.encoder_fade_ms || self.opts.modify();
     }
 }

--- a/gateware/src/rs/lib/src/ui.rs
+++ b/gateware/src/rs/lib/src/ui.rs
@@ -62,6 +62,10 @@ impl<EncoderT: Encoder,
         self.touch_led_mask = mask;
     }
 
+    pub fn draw(&self) -> bool {
+        self.draw
+    }
+
     pub fn update(&mut self) {
         //
         // Consume encoder, update options

--- a/gateware/src/top/bootloader/fw/src/opts.rs
+++ b/gateware/src/top/bootloader/fw/src/opts.rs
@@ -41,7 +41,6 @@ impl_option_view!(BootOptions,
 #[derive(Clone)]
 pub struct Options {
     pub modify: bool,
-    pub draw:bool,
     pub screen: EnumOption<Screen>,
 
     pub boot: BootOptions,
@@ -60,7 +59,6 @@ impl Options {
         }
         Options {
             modify: false,
-            draw: true,
             screen: EnumOption {
                 name: String::from_str("screen").unwrap(),
                 value: Screen::Boot,

--- a/gateware/src/top/macro_osc/fw/src/opts.rs
+++ b/gateware/src/top/macro_osc/fw/src/opts.rs
@@ -108,7 +108,6 @@ impl_option_view!(ScopeOptions,
 #[derive(Clone)]
 pub struct Options {
     pub modify: bool,
-    pub draw:   bool,
     pub screen: EnumOption<Screen>,
 
     pub osc:    OscOptions,
@@ -128,7 +127,6 @@ impl Options {
     pub fn new() -> Options {
         Options {
             modify: false,
-            draw:   true,
             screen: EnumOption {
                 name: String::from_str("screen").unwrap(),
                 value: Screen::Osc,

--- a/gateware/src/top/polysyn/fw/src/opts.rs
+++ b/gateware/src/top/polysyn/fw/src/opts.rs
@@ -94,7 +94,6 @@ impl_option_view!(UsbOptions,
 #[derive(Clone)]
 pub struct Options {
     pub modify: bool,
-    pub draw: bool,
     pub screen: EnumOption<Screen>,
 
     pub help:   HelpOptions,
@@ -115,7 +114,6 @@ impl Options {
     pub fn new() -> Options {
         Options {
             modify: true,
-            draw: true,
             screen: EnumOption {
                 name: String::from_str("screen").unwrap(),
                 value: Screen::Help,

--- a/gateware/src/top/selftest/fw/src/main.rs
+++ b/gateware/src/top/selftest/fw/src/main.rs
@@ -21,26 +21,19 @@ use embedded_graphics::{
 use heapless::String;
 
 use tiliqua_pac as pac;
-use tiliqua_hal as hal;
 use tiliqua_fw::*;
 use tiliqua_lib::*;
 use tiliqua_lib::generated_constants::*;
 use tiliqua_lib::draw;
 use tiliqua_lib::calibration::*;
 use tiliqua_fw::opts::*;
-use tiliqua_hal::pmod::EurorackPmod;
 use tiliqua_hal::video::Video;
+use tiliqua_hal::pmod::EurorackPmod;
+use tiliqua_hal::pca9635::Pca9635Driver;
 
 const TUSB322I_ADDR:  u8 = 0x47;
 
 use opts::Options;
-use hal::pca9635::Pca9635Driver;
-
-impl_ui!(UI,
-         Options,
-         Encoder0,
-         Pca9635Driver<I2c0>,
-         EurorackPmod0);
 
 pub type ReportString = String<512>;
 
@@ -304,7 +297,7 @@ fn print_die_temperature(s: &mut ReportString, dtr: &pac::DTR0)
 }
 
 struct App {
-    ui: UI,
+    ui: ui::UI<Encoder0, EurorackPmod0, I2c0, Options>,
 }
 
 impl App {
@@ -315,8 +308,8 @@ impl App {
         let i2cdev = I2c0::new(peripherals.I2C0);
         let pca9635 = Pca9635Driver::new(i2cdev);
         Self {
-            ui: UI::new(opts, TIMER0_ISR_PERIOD_MS,
-                        encoder, pca9635, pmod),
+            ui: ui::UI::new(opts, TIMER0_ISR_PERIOD_MS,
+                            encoder, pca9635, pmod),
         }
     }
 }

--- a/gateware/src/top/selftest/fw/src/opts.rs
+++ b/gateware/src/top/selftest/fw/src/opts.rs
@@ -151,7 +151,6 @@ impl_option_view!(CalOptions,
 #[derive(Clone)]
 pub struct Options {
     pub modify: bool,
-    pub draw: bool,
     pub screen: EnumOption<Screen>,
 
     pub report: ReportOptions,
@@ -171,7 +170,6 @@ impl Options {
     pub fn new() -> Options {
         Options {
             modify: true,
-            draw: true,
             screen: EnumOption {
                 name: String::from_str("screen").unwrap(),
                 value: Screen::Report,

--- a/gateware/src/top/sid/fw/src/main.rs
+++ b/gateware/src/top/sid/fw/src/main.rs
@@ -28,18 +28,12 @@ use hal::pca9635::Pca9635Driver;
 
 use micromath::F32Ext;
 
-impl_ui!(UI,
-         Options,
-         Encoder0,
-         Pca9635Driver<I2c0>,
-         EurorackPmod0);
-
 tiliqua_hal::impl_dma_display!(DMADisplay, H_ACTIVE, V_ACTIVE, VIDEO_ROTATE_90);
 
 pub const TIMER0_ISR_PERIOD_MS: u32 = 10;
 
 struct App {
-    ui: UI,
+    ui: ui::UI<Encoder0, EurorackPmod0, I2c0, Options>,
 }
 
 impl App {
@@ -50,8 +44,8 @@ impl App {
         let pca9635 = Pca9635Driver::new(i2cdev);
         let pmod = EurorackPmod0::new(peripherals.PMOD0_PERIPH);
         Self {
-            ui: UI::new(opts, TIMER0_ISR_PERIOD_MS,
-                        encoder, pca9635, pmod),
+            ui: ui::UI::new(opts, TIMER0_ISR_PERIOD_MS,
+                            encoder, pca9635, pmod),
         }
     }
 }

--- a/gateware/src/top/sid/fw/src/opts.rs
+++ b/gateware/src/top/sid/fw/src/opts.rs
@@ -167,7 +167,6 @@ impl_option_view!(ModulateOptions,
 #[derive(Clone)]
 pub struct Options {
     pub modify: bool,
-    pub draw: bool,
     pub screen: EnumOption<Screen>,
     pub modulate: ModulateOptions,
     pub voice1: VoiceOptions,
@@ -272,7 +271,6 @@ impl Options {
     pub fn new() -> Options {
         Options {
             modify: false,
-            draw: true,
             screen: EnumOption {
                 name: String::from_str("screen").unwrap(),
                 value: Screen::Voice1,

--- a/gateware/src/top/xbeam/fw/src/opts.rs
+++ b/gateware/src/top/xbeam/fw/src/opts.rs
@@ -68,7 +68,6 @@ impl_option_view!(ScopeOptions,
 #[derive(Clone)]
 pub struct Options {
     pub modify: bool,
-    pub draw: bool,
     pub screen: EnumOption<Screen>,
 
     pub vector: VectorOptions,
@@ -86,7 +85,6 @@ impl Options {
     pub fn new() -> Options {
         Options {
             modify: false,
-            draw: true,
             screen: EnumOption {
                 name: String::from_str("screen").unwrap(),
                 value: Screen::Vector,


### PR DESCRIPTION
The shared UI implementation did not need to live in a macro. Switch it out for ordinary generics, making it possible to use in unit tests more easily.