### PR TITLE
bootloader: add mitigation for DVI leakage current (issue #81)

### DIFF
--- a/gateware/docs/hardware.rst
+++ b/gateware/docs/hardware.rst
@@ -1,35 +1,42 @@
-Hardware overview
-#################
+Connecting Hardware
+###################
 
-Front
------
+Connections: Front
+------------------
 
 .. image:: _static/tiliqua_front_labelled.png
   :width: 800
 
-Back
-----
+Connections: Back
+-----------------
 
 .. image:: _static/tiliqua_rear_labelled.jpg
   :width: 800
 
-Power ingress
--------------
+Power: connecting +/- 12V
+-------------------------
 
 .. warning::
 
     Tiliqua uses an ordinary 10-pin power cable for +/- 12V ingress. You will notice however, that there are 2 such connectors on the module. **Only ONE of these should be connected**:
 
-    - Use the 10-pin power ingress on the Tiliqua Motherboard, not the Audio Interface Board. Technically both will work, but only the former is fused.
+    - Use the 10-pin power ingress **on the Tiliqua Motherboard, not the Audio Interface Board**. Technically both will work, but only the former is fused.
     - Both connectors on the audio interface board (eurorack-pmod) should remain unconnected.
     - Make sure the red stripe on the IDC cable is aligned with the RED marker on the PCB.
 
-Debug USB port
---------------
+USB: the ``dbg`` and ``usb2`` ports
+-----------------------------------
 
-For flashing bitstreams, usually you want to be connected to the dbg USB port. This is directly connected to the on-board RP2040 which is flashed with dirtyJtag, such that you can flash bitstreams using openFPGALoader.
+For flashing bitstreams, you want the ``dbg`` USB port. This is routed to the on-board RP2040 which is flashed with ``dirtyJtag``, which allows flashing the SPI flash with ``openFPGALoader``.
 
-Audio jacks and capsense
-------------------------
+For USB audio or USB device / host usage from bitstreams, you want the ``usb2`` USB port. This is routed through a ULPI PHY directly to the FPGA fabric.
 
-Particularly for bitstreams with touch sensing, ensure all jacks are disconnected when the tiliqua is powered on. This is because the capacitive sensing is calibrated when the system boots. In theory, this could happen every time something is dis/re-connected, but hasn't been implemented yet.
+Audio jacks: for touch, disconnect on boot
+------------------------------------------
+
+When using bitstreams with touch sensing, **ensure all jacks are disconnected before the tiliqua is powered on**. This is because the capacitive sensing is calibrated when the system boots. In the future, re-calibration will happen every time something is dis/re-connected, but this is not the case yet.
+
+Display/DVI: disconnect when system off
+---------------------------------------
+
+External displays (e.g. external monitors not sharing Eurorack power) may leak a small current to the FPGA through the DVI termination resistors if Tiliqua is off. This will not affect Tiliqua operation, but may affect the 3V3 supply on PMOD expansion modules. By always **disconnecting the display when your eurorack system is off**, you can avoid this leakage current.

--- a/gateware/src/rs/hal/src/pmod.rs
+++ b/gateware/src/rs/hal/src/pmod.rs
@@ -9,6 +9,7 @@ pub trait EurorackPmod {
     fn led_all_manual(&mut self);
     fn write_calibration_constant(&mut self, ch: u8, a: i32, b: i32);
     fn mute(&mut self, mute: bool);
+    fn hard_reset(&mut self);
 }
 
 #[macro_export]
@@ -111,6 +112,10 @@ macro_rules! impl_eurorack_pmod {
 
                 fn mute(&mut self, mute: bool) {
                     self.registers.flags().write(|w| w.mute().bit(mute) );
+                }
+
+                fn hard_reset(&mut self) {
+                    self.registers.flags().write(|w| w.hard_reset().bit(true) );
                 }
             }
         )+

--- a/gateware/src/tiliqua/eurorack_pmod_peripheral.py
+++ b/gateware/src/tiliqua/eurorack_pmod_peripheral.py
@@ -39,6 +39,7 @@ class Peripheral(wiring.Component):
 
     class FlagsReg(csr.Register, access="w"):
         mute: csr.Field(csr.action.W, unsigned(1))
+        hard_reset: csr.Field(csr.action.W, unsigned(1))
 
     class CalibrationConstant(csr.Register, access="w"):
         value: csr.Field(csr.action.W, signed(32))
@@ -101,6 +102,10 @@ class Peripheral(wiring.Component):
         m.d.comb += self.pmod.codec_mute.eq(mute_reg | self.mute)
         with m.If(self._flags.f.mute.w_stb):
             m.d.sync += mute_reg.eq(self._flags.f.mute.w_data)
+
+        with m.If(self._flags.f.hard_reset.w_stb & self._flags.f.hard_reset.w_data):
+            # Strobe PMOD hard reset.
+            m.d.comb += self.pmod.hard_reset.eq(1)
 
         with m.If(self._led_mode.f.led.w_stb):
             m.d.sync += self.pmod.led_mode.eq(self._led_mode.f.led.w_data)

--- a/gateware/src/top/bootloader/fw/src/main.rs
+++ b/gateware/src/top/bootloader/fw/src/main.rs
@@ -387,6 +387,11 @@ fn main() -> ! {
         None
     };
 
+    let mut i2cdev1 = I2c1::new(peripherals.I2C1);
+    let mut pmod = EurorackPmod0::new(peripherals.PMOD0_PERIPH);
+    maybe_restart_codec(&mut i2cdev1, &mut pmod);
+    calibration::CalibrationConstants::load_or_default(&mut i2cdev1, &mut pmod);
+
     let mut manifests: [Option<BitstreamManifest>; 8] = [const { None }; 8];
     for n in 0usize..N_MANIFESTS {
         let size: usize = MANIFEST_SIZE;
@@ -395,11 +400,6 @@ fn main() -> ! {
         info!("(entry {}) look for manifest from {:#x} to {:#x}", n, addr, addr+size);
         manifests[n] = BitstreamManifest::from_addr(addr, size);
     }
-
-    let mut i2cdev1 = I2c1::new(peripherals.I2C1);
-    let mut pmod = EurorackPmod0::new(peripherals.PMOD0_PERIPH);
-    maybe_restart_codec(&mut i2cdev1, &mut pmod);
-    calibration::CalibrationConstants::load_or_default(&mut i2cdev1, &mut pmod);
 
     let mut opts = Opts::default();
     // Populate option string values with bitstream names from manifest.


### PR DESCRIPTION
From https://github.com/apfaudio/tiliqua/issues/81:

```
After some probing, turns out this is a hardware artifact (!!) related to the soft-mute circuit. When a DVI sink (i.e a display) has its 3.3V terminations enabled (usually only a few seconds after an active display connection), it may back-power the Tiliqua through the 50R (sink) + 220R (tiliqua) series resistors into the ECP5. According to the ECP5 datasheet, this is permissible (even if the ECP5 is off). So it should not damage the hardware at least.

The consequence is we see ~1V on the 3.3V rail in this specific scenario, even if the Tiliqua is off. This means the soft-mute circuit never fully deasserts the PDN pin to the audio CODEC when the Tiliqua is powered off, which is required to initialize the CODEC correctly.
```

As a mitigation, in the bootloader, if we detect the CODEC did not initialize correctly, we pulse a zero on PDN and re-initialize it. This is ONLY performed if we detect the CODEC did not initialize correctly, otherwise it would break soft-mute between bitstreams (where the bootloader also executes.
