### PR TITLE
bootloader/flasher: pop-free bitstream flashing from bootloader

### DIFF
--- a/gateware/docs/bootloader.rst
+++ b/gateware/docs/bootloader.rst
@@ -63,11 +63,60 @@ Bitstream Archives and Flash Memory Layout
 Each bitstream archive contains:
 
 - Bitstream file (top.bit)
-- Firmware binary (if applicable) 
+- Firmware binary (if applicable)
 - Any extra resources to be loaded into PSRAM (if applicable)
 - Manifest file describing the contents
 
-The flash tool manages the following memory layout on the FPGA's 16MByte SPI flash:
+The flash tool manages the following memory layout on the SoldierCrab's 128Mbit SPI flash:
+
+.. code-block:: text
+
+    ┌────────────────────────────┐  0x000000
+    │                            │
+    │    Bootloader Bitstream    │
+    │                            │
+    ├────────────────────────────┤
+    │          (padding)         │
+    ├────────────────────────────┤  0x0B0000
+    │                            │
+    │    Bootloader FW (XiP)     │
+    │                            │
+    ├────────────────────────────┤
+    │          (padding)         │
+    ╞════════════════════════════╡  0x100000
+    │                            │
+    │      Slot 0 Bitstream      │
+    │                            │
+    ├────────────────────────────┤
+    │          (padding)         │
+    ├────────────────────────────┤  0x1B0000
+    │                            │
+    │        Slot 0 FW           │
+    │  NOT XiP, copied to PSRAM  │
+    │                            │
+    ├────────────────────────────┤  (any additional slot 0 resources appended here)
+    │          (padding)         │
+    ├────────────────────────────┤  0x1FFC00
+    │      Slot 0 Manifest       │
+    ╞════════════════════════════╡  0x200000 (End of Slot 0, start of Slot 1)
+    │                            │
+    │      Slot 1 Bitstream      │
+    │                            │
+    ├────────────────────────────┤
+    │          (padding)         │
+    ├────────────────────────────┤  0x2B0000
+    │                            │
+    │        Slot 1 FW           │
+    │  NOT XiP, copied to PSRAM  │
+    │                            │
+    ├────────────────────────────┤ (any additional slot 1 resources appended here)
+    │          (padding)         │
+    ├────────────────────────────┤  0x2FFC00
+    │       Slot 1 Manifest      │
+    ╞════════════════════════════╡  0x300000 (End of Slot 1, start of Slot 2)
+    │                            │
+
+    ... continued up to Slot 7
 
 - Bootloader bitstream: 0x000000
 - User bitstream slots: 0x100000, 0x200000, etc (1MB spacing)
@@ -77,7 +126,7 @@ The flash tool manages the following memory layout on the FPGA's 16MByte SPI fla
 The manifest includes metadata like the bitstream name and version, as well as information about where firmware should be loaded in PSRAM.
 
 If an image requires firmware loaded to PSRAM, the SPI flash source address (in the manifest) is set to the true firmware base address by the flash tool when it is flashed.
-That is, the value of spiflash_src is not preserved by the flash tool and instead depends on the slot number.
+That is, the value of ``spiflash_src`` is not preserved by the flash tool and instead depends on the slot number.
 This allows a bitstream that requires firmware to be loaded to PSRAM to be flashed to any slot, and the bootloader will load the firmware from the correct address.
 
 Implementation details: ECP5

--- a/gateware/docs/gettingstarted.rst
+++ b/gateware/docs/gettingstarted.rst
@@ -61,6 +61,10 @@ Such archives may be flashed as follows:
    pdm flash archive build/xbeam-*.tar.gz --slot 2
    pdm flash status # check what is on the Tiliqua
 
+.. note::
+
+    If you want to avoid audio pops while flashing, it is best to flash from the bootloader bitstream, as the audio CODEC is always muted in that bitstream.
+
 If you are running an SoC, you can monitor serial output like so:
 
 .. code-block:: bash

--- a/gateware/src/tiliqua/flash.py
+++ b/gateware/src/tiliqua/flash.py
@@ -13,6 +13,8 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+from pathlib import Path
+from typing import Dict, List, Tuple, Optional, Any
 
 # Flash memory map constants shared with the bootloader
 from rs.manifest.src.lib import (
@@ -24,11 +26,49 @@ from rs.manifest.src.lib import (
 
 # Flash memory map constants
 BOOTLOADER_BITSTREAM_ADDR = 0x000000
-FIRMWARE_BASE_SLOT0      = 0x1B0000
-FLASH_PAGE_SIZE          = 1024 # 1KB
+FIRMWARE_BASE_SLOT0 = 0x1B0000
+FLASH_PAGE_SIZE = 1024  # 1KB
 
-def flash_file(file_path, offset, file_type="auto", dry_run=True):
-    """Flash a file to the specified offset using openFPGALoader."""
+class Region:
+    """Flash memory region descriptor."""
+    def __init__(self, addr: int, size: int, name: str):
+        self.addr = addr
+        self.size = size
+        self.name = name
+
+    @property
+    def aligned_size(self) -> int:
+        """Return size aligned up to page boundary."""
+        return (self.size + FLASH_PAGE_SIZE - 1) & ~(FLASH_PAGE_SIZE - 1)
+        
+    @property
+    def end_addr(self) -> int:
+        """Return end address (exclusive)."""
+        return self.addr + self.aligned_size
+        
+    def __lt__(self, other):
+        """Enable sorting regions by address."""
+        return self.addr < other.addr
+        
+    def __str__(self) -> str:
+        return (f"{self.name}:\n"
+                f"  start: 0x{self.addr:x}\n"
+                f"  end:   0x{self.addr + self.aligned_size - 1:x}")
+
+
+def flash_file(file_path: str, offset: int, file_type: str = "auto", dry_run: bool = True) -> List[str]:
+    """
+    Generate or execute the openFPGALoader command to flash a file to the specified offset.
+    
+    Args:
+        file_path: Path to the file to flash
+        offset: Flash memory offset
+        file_type: File type for openFPGALoader
+        dry_run: If True, return command instead of executing it
+        
+    Returns:
+        Command list if dry_run is True, otherwise None after executing the command
+    """
     cmd = [
         "sudo", "openFPGALoader", "-c", "dirtyJtag",
         "-f", "-o", f"{hex(offset)}",
@@ -36,202 +76,104 @@ def flash_file(file_path, offset, file_type="auto", dry_run=True):
     if file_type != "auto":
         cmd.extend(["--file-type", file_type])
     cmd.append(file_path)
+    
     if dry_run:
         return cmd
-    else:
-        print(f"Flashing to {hex(offset)}:")
-        print("\t$", " ".join(cmd))
-        subprocess.check_call(cmd)
+    
+    print(f"Flashing to {hex(offset)}:")
+    print(f"\t$ {' '.join(cmd)}")
+    subprocess.check_call(cmd)
+    return None
 
-def check_region_overlaps(regions, slot=None):
+
+def check_region_overlaps(regions: List[Region], slot: Optional[int] = None) -> Tuple[bool, str]:
     """
     Check for overlapping regions in flash commands and slot boundaries.
-    Each region is aligned up before checking.
-    Returns (bool, str) tuple: (has_overlap, error_message)
+    
+    Args:
+        regions: List of Region objects to check
+        slot: Slot number for checking slot boundary constraints
+        
+    Returns:
+        Tuple of (has_overlap, error_message)
     """
-    # Convert regions to (start, end) tuples, with aligned sizes
-    aligned_regions = []
-    for r in regions:
-        start = r['addr']
-        size = (r['size'] + FLASH_PAGE_SIZE - 1) & ~(FLASH_PAGE_SIZE - 1)  # Align up
-        end = start + size
-        aligned_regions.append((start, end, r['name']))
-
-        # For non-XIP firmware, check if any region exceeds its slot
-        if slot is not None:
-            slot_start = (start // SLOT_SIZE) * SLOT_SIZE
+    # For non-XIP firmware, check if any region exceeds its slot
+    if slot is not None:
+        for region in regions:
+            slot_start = (region.addr // SLOT_SIZE) * SLOT_SIZE
             slot_end = slot_start + SLOT_SIZE
-            if end > slot_end:
-                return (True, f"Region '{r['name']}' exceeds slot boundary: "
-                            f"ends at 0x{end:x}, slot ends at 0x{slot_end:x}")
+            if region.end_addr > slot_end:
+                return (True, f"Region '{region.name}' exceeds slot boundary: "
+                             f"ends at 0x{region.end_addr:x}, slot ends at 0x{slot_end:x}")
 
-    # Sort by start address
-    aligned_regions.sort()
-
-    # Check for overlaps
-    for i in range(len(aligned_regions) - 1):
-        curr_end = aligned_regions[i][1]
-        next_start = aligned_regions[i + 1][0]
+    # Sort by start address and check for overlaps
+    sorted_regions = sorted(regions)
+    for i in range(len(sorted_regions) - 1):
+        curr_end = sorted_regions[i].end_addr
+        next_start = sorted_regions[i + 1].addr
         if curr_end > next_start:
-            return (True, f"Overlap detected between '{aligned_regions[i][2]}' (ends at 0x{curr_end:x}) "
-                         f"and '{aligned_regions[i+1][2]}' (starts at 0x{next_start:x})")
+            return (True, f"Overlap detected between '{sorted_regions[i].name}' (ends at 0x{curr_end:x}) "
+                          f"and '{sorted_regions[i+1].name}' (starts at 0x{next_start:x})")
+                          
     return (False, "")
 
-def flash_archive(archive_path, slot=None, noconfirm=False):
+
+def flash_archive(archive_path: str, slot: Optional[int] = None, noconfirm: bool = False) -> None:
     """
     Flash a bitstream archive to the specified slot.
-    For XIP firmware, slot must be None as it can only go in the bootloader slot (0x0).
+    
+    Args:
+        archive_path: Path to the bitstream archive
+        slot: Slot number for bootloader-managed bitstreams
+        noconfirm: Skip confirmation prompt if True
     """
     commands_to_run = []
-    regions_to_check = []
+    regions = []
 
     # Extract archive to temporary location
     with tarfile.open(archive_path, "r:gz") as tar:
         # Read manifest first
         manifest_info = tar.getmember("manifest.json")
         manifest_f = tar.extractfile(manifest_info)
+        if not manifest_f:
+            print("Error: Could not extract manifest.json from archive")
+            sys.exit(1)
         manifest = json.load(manifest_f)
 
         # Check if this is an XIP firmware
         has_xip_firmware = False
-        if manifest.get("regions"):
-            for region in manifest["regions"]:
-                if region.get("spiflash_src") is not None:
-                    has_xip_firmware = True
-                    xip_offset = region["spiflash_src"]
-                    break
+        xip_offset = None
+        for region in manifest.get("regions", []):
+            if region.get("spiflash_src") is not None:
+                has_xip_firmware = True
+                xip_offset = region["spiflash_src"]
+                break
 
-        if has_xip_firmware:
-            if slot is not None:
-                print("Error: XIP firmware bitstreams must be flashed to bootloader slot")
-                print(f"Remove --slot argument to flash at 0x0 with firmware at 0x{xip_offset:x}")
-                sys.exit(1)
-        else:
-            if slot is None:
-                print("Error: Must specify slot for non-XIP firmware bitstreams")
-                sys.exit(1)
+        if has_xip_firmware and slot is not None:
+            print("Error: XIP firmware bitstreams must be flashed to bootloader slot")
+            print(f"Remove --slot argument to flash at 0x0 with firmware at 0x{xip_offset:x}")
+            sys.exit(1)
+        elif not has_xip_firmware and slot is None:
+            print("Error: Must specify slot for non-XIP firmware bitstreams")
+            sys.exit(1)
 
         # Create temp directory for extracted files
         with tempfile.TemporaryDirectory() as tmpdir:
             tar.extractall(tmpdir)
-
+            tmpdir_path = Path(tmpdir)
+            
             if has_xip_firmware:
-                print("\nPreparing to flash XIP firmware bitstream to bootloader slot...")
-                # Collect commands for bootloader location
-                commands_to_run.append(
-                    flash_file(
-                        os.path.join(tmpdir, "top.bit"),
-                        BOOTLOADER_BITSTREAM_ADDR,
-                        dry_run=True
-                    )
-                )
-                # Add bootloader bitstream region
-                regions_to_check.append({
-                    'addr': BOOTLOADER_BITSTREAM_ADDR,
-                    'size': os.path.getsize(os.path.join(tmpdir, "top.bit")),
-                    'name': 'bootloader bitstream'
-                })
-
-                # Collect commands for XIP firmware
-                # Add XIP firmware regions
-                for region in manifest["regions"]:
-                    if "filename" not in region:
-                        continue
-                    commands_to_run.append(
-                        flash_file(
-                            os.path.join(tmpdir, region["filename"]),
-                            region["spiflash_src"],
-                            "raw",
-                            dry_run=True
-                        )
-                    )
-                    regions_to_check.append({
-                        'addr': region["spiflash_src"],
-                        'size': region["size"],
-                        'name': f"firmware '{region['filename']}'"
-                    })
+                handle_xip_firmware(tmpdir_path, manifest, commands_to_run, regions)
             else:
-                print(f"\nPreparing to flash bitstream to slot {slot}...")
-                # Calculate addresses for this slot
-                slot_base = SLOT_BITSTREAM_BASE + (slot * SLOT_SIZE)
-                bitstream_addr = slot_base
-                manifest_addr = (slot_base + SLOT_SIZE) - MANIFEST_SIZE
-                firmware_base = FIRMWARE_BASE_SLOT0 + (slot * SLOT_SIZE)
-
-                # Add bitstream region
-                regions_to_check.append({
-                    'addr': bitstream_addr,
-                    'size': os.path.getsize(os.path.join(tmpdir, "top.bit")),
-                    'name': 'bitstream'
-                })
-
-                # Add manifest region
-                regions_to_check.append({
-                    'addr': manifest_addr,
-                    'size': MANIFEST_SIZE,
-                    'name': 'manifest'
-                })
-
-                # Update manifest and add firmware regions
-                for region in manifest["regions"]:
-                    if "filename" not in region:
-                        continue
-                    if region.get("psram_dst") is not None:
-                        assert "spiflash_src" not in region or region["spiflash_src"] is None
-                        region["spiflash_src"] = firmware_base
-                        print(f"manifest: region {region['filename']}: spiflash_src set to 0x{firmware_base:x}")
-                        regions_to_check.append({
-                            'addr': firmware_base,
-                            'size': region["size"],
-                            'name': region['filename'],
-                        })
-                        firmware_base += region["size"]
-                        firmware_base = (firmware_base + 0xFFF) & ~0xFFF
-
-                # Write updated manifest
-                manifest_path = os.path.join(tmpdir, "manifest.json")
-                print(f"\nFinal manifest contents:\n{json.dumps(manifest, indent=2)}")
-                with open(manifest_path, "w") as f:
-                    json.dump(manifest, f)
-
-                # Collect all commands
-                commands_to_run.append(
-                    flash_file(
-                        os.path.join(tmpdir, "top.bit"),
-                        bitstream_addr,
-                        dry_run=True
-                    )
-                )
-                commands_to_run.append(
-                    flash_file(
-                        manifest_path,
-                        manifest_addr,
-                        "raw",
-                        dry_run=True
-                    )
-                )
-                for region in manifest["regions"]:
-                    if "filename" not in region or "spiflash_src" not in region:
-                        continue
-                    commands_to_run.append(
-                        flash_file(
-                            os.path.join(tmpdir, region["filename"]),
-                            region["spiflash_src"],
-                            "raw",
-                            dry_run=True
-                        )
-                    )
+                handle_slotted_firmware(tmpdir_path, manifest, slot, commands_to_run, regions)
 
             # Print all regions
             print("\nRegions to be flashed:")
-            for region in sorted(regions_to_check, key=lambda r: r['addr']):
-                aligned_size = (region['size'] + FLASH_PAGE_SIZE - 1) & ~(FLASH_PAGE_SIZE - 1)
-                print(f"  {region['name']}:")
-                print(f"    start: 0x{region['addr']:x}")
-                print(f"    end:   0x{region['addr']+aligned_size-1:x}")
+            for region in sorted(regions):
+                print(f"  {region}")
 
             # Check for overlaps before proceeding
-            has_overlap, error_msg = check_region_overlaps(regions_to_check, slot)
+            has_overlap, error_msg = check_region_overlaps(regions, slot)
             if has_overlap:
                 print(f"Error: {error_msg}")
                 sys.exit(1)
@@ -239,13 +181,11 @@ def flash_archive(archive_path, slot=None, noconfirm=False):
             # Show all commands and get confirmation
             print("\nThe following commands will be executed:")
             for cmd in commands_to_run:
-                print("\t$", " ".join(cmd))
+                print(f"\t$ {' '.join(cmd)}")
 
-            if not noconfirm:
-                response = input("\nProceed with flashing? [y/N] ")
-                if response.lower() != 'y':
-                    print("Aborting.")
-                    sys.exit(0)
+            if not noconfirm and not confirm_operation():
+                print("Aborting.")
+                sys.exit(0)
 
             # Execute all commands
             print("\nExecuting flash commands...")
@@ -254,67 +194,219 @@ def flash_archive(archive_path, slot=None, noconfirm=False):
 
             print("\nFlashing completed successfully")
 
-def read_flash_segment(offset, size, reset=False):
-    """Read a segment of flash memory to a temporary file and return its contents."""
-    with tempfile.NamedTemporaryFile(suffix='.bin', delete=True) as tmp_file:
-        temp_file_name = tmp_file.name
-    cmd = [
-        "sudo", "openFPGALoader", "-c", "dirtyJtag",
-        "--dump-flash", "-o", f"{hex(offset)}",
-        "--file-size", str(size),
-    ]
-    if not reset:
-        cmd.append("--skip-reset")
-    cmd.append(temp_file_name)
-    print(" ".join(cmd))
-    subprocess.check_call(cmd)
-    with open(temp_file_name, 'rb') as f:
-        data = f.read()
-    return data
 
-def is_empty_flash(data):
+def handle_xip_firmware(tmpdir: Path, manifest: Dict, commands: List, regions: List) -> None:
+    """
+    Handle XIP firmware bitstream flashing preparation.
+    
+    Args:
+        tmpdir: Temporary directory with extracted files
+        manifest: Parsed manifest.json
+        commands: List to append commands to
+        regions: List to append regions to
+    """
+    print("\nPreparing to flash XIP firmware bitstream to bootloader slot...")
+    
+    # Prepare bootloader bitstream
+    bitstream_path = tmpdir / "top.bit"
+    bitstream_size = os.path.getsize(bitstream_path)
+    
+    # Collect commands for bootloader location
+    commands.append(flash_file(str(bitstream_path), BOOTLOADER_BITSTREAM_ADDR, dry_run=True))
+    
+    # Add bootloader bitstream region
+    regions.append(Region(BOOTLOADER_BITSTREAM_ADDR, bitstream_size, 'bootloader bitstream'))
+
+    # Collect commands for XIP firmware regions
+    for region_info in manifest.get("regions", []):
+        if "filename" not in region_info:
+            continue
+            
+        region_path = tmpdir / region_info["filename"]
+        region_addr = region_info["spiflash_src"]
+        
+        commands.append(flash_file(
+            str(region_path),
+            region_addr,
+            "raw",
+            dry_run=True
+        ))
+        
+        regions.append(Region(
+            region_addr,
+            region_info["size"],
+            f"firmware '{region_info['filename']}'"
+        ))
+
+
+def handle_slotted_firmware(tmpdir: Path, manifest: Dict, slot: int, commands: List, regions: List) -> None:
+    """
+    Handle slotted firmware bitstream flashing preparation.
+    
+    Args:
+        tmpdir: Temporary directory with extracted files
+        manifest: Parsed manifest.json
+        slot: Slot number
+        commands: List to append commands to
+        regions: List to append regions to
+    """
+    print(f"\nPreparing to flash bitstream to slot {slot}...")
+    
+    # Calculate addresses for this slot
+    slot_base = SLOT_BITSTREAM_BASE + (slot * SLOT_SIZE)
+    bitstream_addr = slot_base
+    manifest_addr = (slot_base + SLOT_SIZE) - MANIFEST_SIZE
+    firmware_base = FIRMWARE_BASE_SLOT0 + (slot * SLOT_SIZE)
+
+    # Add bitstream region
+    bitstream_path = tmpdir / "top.bit"
+    bitstream_size = os.path.getsize(bitstream_path)
+    regions.append(Region(bitstream_addr, bitstream_size, 'bitstream'))
+
+    # Add manifest region
+    regions.append(Region(manifest_addr, MANIFEST_SIZE, 'manifest'))
+
+    # Update manifest and add firmware regions
+    for region_info in manifest.get("regions", []):
+        if "filename" not in region_info:
+            continue
+            
+        if region_info.get("psram_dst") is not None:
+            if region_info.get("spiflash_src") is not None:
+                assert region_info["spiflash_src"] is None, "Both psram_dst and spiflash_src set"
+                
+            region_info["spiflash_src"] = firmware_base
+            print(f"manifest: region {region_info['filename']}: spiflash_src set to 0x{firmware_base:x}")
+            
+            regions.append(Region(
+                firmware_base,
+                region_info["size"],
+                region_info['filename']
+            ))
+            
+            # Align firmware base to next 4KB boundary (0x1000)
+            firmware_base += region_info["size"]
+            firmware_base = (firmware_base + 0xFFF) & ~0xFFF
+
+    # Write updated manifest
+    manifest_path = tmpdir / "manifest.json"
+    print(f"\nFinal manifest contents:\n{json.dumps(manifest, indent=2)}")
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f)
+
+    # Collect all commands
+    commands.append(flash_file(str(bitstream_path), bitstream_addr, dry_run=True))
+    commands.append(flash_file(str(manifest_path), manifest_addr, "raw", dry_run=True))
+    
+    for region_info in manifest.get("regions", []):
+        if "filename" not in region_info or "spiflash_src" not in region_info:
+            continue
+            
+        region_path = tmpdir / region_info["filename"]
+        commands.append(flash_file(
+            str(region_path),
+            region_info["spiflash_src"],
+            "raw",
+            dry_run=True
+        ))
+
+
+def read_flash_segment(offset: int, size: int, reset: bool = False) -> bytes:
+    """
+    Read a segment of flash memory to a temporary file and return its contents.
+    
+    Args:
+        offset: Flash memory offset
+        size: Number of bytes to read
+        reset: Whether to reset the device after reading
+        
+    Returns:
+        Binary data read from flash
+    """
+    with tempfile.NamedTemporaryFile(suffix='.bin', delete=False) as tmp_file:
+        temp_file_name = tmp_file.name
+        
+    try:
+        cmd = [
+            "sudo", "openFPGALoader", "-c", "dirtyJtag",
+            "--dump-flash", "-o", f"{hex(offset)}",
+            "--file-size", str(size),
+        ]
+        
+        if not reset:
+            cmd.append("--skip-reset")
+            
+        cmd.append(temp_file_name)
+        print(" ".join(cmd))
+        subprocess.check_call(cmd)
+        
+        with open(temp_file_name, 'rb') as f:
+            data = f.read()
+            
+        return data
+    finally:
+        os.unlink(temp_file_name)
+
+
+def is_empty_flash(data: bytes) -> bool:
     """Check if a flash segment is empty (all 0xFF)."""
     return all(b == 0xFF for b in data)
 
-def parse_json_from_flash(data):
-    """Try to parse JSON data from a flash segment."""
+
+def parse_json_from_flash(data: bytes) -> Optional[Dict]:
+    """
+    Try to parse JSON data from a flash segment.
+    
+    Args:
+        data: Binary data to parse
+        
+    Returns:
+        Parsed JSON object or None if parsing failed
+    """
     try:
         # Find the end of the JSON data (null terminator or 0xFF)
-        end_idx = data.find(b'\x00')
-        if end_idx == -1:
-            end_idx = data.find(b'\xff')
-        if end_idx == -1:
+        for delimiter in [b'\x00', b'\xff']:
+            end_idx = data.find(delimiter)
+            if end_idx != -1:
+                break
+        else:
             end_idx = len(data)
+            
         json_bytes = data[:end_idx]
         return json.loads(json_bytes)
     except json.JSONDecodeError:
         return None
 
-def flash_status():
+
+def flash_status() -> None:
     """Display the status of flashed bitstreams in each manifest slot."""
-
-    segments = []
-    for n in range(0, N_MANIFESTS):
-        segments.append(
-            {"offset": SLOT_BITSTREAM_BASE+(n+1)*SLOT_SIZE-MANIFEST_SIZE, "size": 512,
-             "name": f"Slot {n} manifest", "data": None})
-
-    for (n, segment) in enumerate(segments):
-        print(f"\nReading {segment['name']} at {hex(segment['offset'])}:")
+    print("Reading manifests from flash...")
+    manifest_data = []
+    
+    # Read all manifests
+    for slot in range(N_MANIFESTS):
+        offset = SLOT_BITSTREAM_BASE + (slot + 1) * SLOT_SIZE - MANIFEST_SIZE
+        is_last = (slot == N_MANIFESTS - 1)
+        
+        print(f"\nReading Slot {slot} manifest at {hex(offset)}:")
         try:
-            segment["data"] = read_flash_segment(segment['offset'], segment['size'], reset=(n==N_MANIFESTS-1))
+            data = read_flash_segment(offset, 512, reset=is_last)
+            manifest_data.append((slot, offset, data))
         except subprocess.CalledProcessError as e:
             print(f"  Error reading flash: {e}")
 
-    print("Manifests:")
+    # Print manifest statuses
+    print("\nManifests:")
     print("-" * 40)
-    for segment in segments:
-        print(f"\nReading {segment['name']} at {hex(segment['offset'])}:")
+    
+    for slot, offset, data in manifest_data:
+        print(f"\nSlot {slot} manifest at {hex(offset)}:")
+        
         try:
-            data = segment["data"]
             if is_empty_flash(data):
-                print(f"  status: empty (all 0xFF)")
+                print("  status: empty (all 0xFF)")
                 continue
+                
             json_data = parse_json_from_flash(data)
             if json_data:
                 print("  status: valid manifest")
@@ -326,18 +418,28 @@ def flash_status():
                 print(f"  first 32 bytes: {data[:32].hex()}")
         except Exception as e:
             print(f"  Error processing data: {e}")
+            
     print("\nNote: empty segments are shown as 'empty (all 0xFF)'")
+
+
+def confirm_operation() -> bool:
+    """Prompt for user confirmation."""
+    response = input("\nProceed with flashing? [y/N] ")
+    return response.lower() == 'y'
+
 
 def main():
     parser = argparse.ArgumentParser(description="Flash Tiliqua bitstream archives")
     subparsers = parser.add_subparsers(dest='command', required=True)
 
+    # Archive command
     archive_parser = subparsers.add_parser('archive', help='Flash a bitstream archive')
     archive_parser.add_argument("archive_path", help="Path to bitstream archive (.tar.gz)")
     archive_parser.add_argument("--slot", type=int, help="Slot number (0-7) for bootloader-managed bitstreams")
     archive_parser.add_argument("--noconfirm", action="store_true", help="Do not ask for confirmation before flashing")
 
-    status_parser = subparsers.add_parser('status', help='Display current bitstream status')
+    # Status command
+    subparsers.add_parser('status', help='Display current bitstream status')
 
     args = parser.parse_args()
 
@@ -351,6 +453,7 @@ def main():
         flash_archive(args.archive_path, args.slot, args.noconfirm)
     elif args.command == 'status':
         flash_status()
+
 
 if __name__ == "__main__":
     main()

--- a/gateware/src/top/bootloader/fw/src/main.rs
+++ b/gateware/src/top/bootloader/fw/src/main.rs
@@ -446,6 +446,9 @@ fn main() -> ! {
 
         loop {
 
+            // Always mute the CODEC to stop pops on flashing while in the bootloader.
+            pmod.mute(true);
+
             let (opts, reboot_n, error_n) = critical_section::with(|cs| {
                 (app.borrow_ref(cs).ui.opts.clone(),
                  app.borrow_ref(cs).reboot_n.clone(),
@@ -474,7 +477,6 @@ fn main() -> ! {
             }
 
             if let Some(_) = reboot_n {
-                pmod.mute(true);
                 print_rebooting(&mut display, &mut rng);
             }
         }


### PR DESCRIPTION
A few changes so that `pdm flash archive` and `pdm flash status` don't cause audio pops when run from the `bootloader` bitstream.
- Always mute audio codec from `bootloader bitstream`
- Always issue `openFPGALoader` commands with `--skip-reset` on all but the last command
- Rewrite `flash.py` so it's a bit more maintainable
- Add some ASCII art showing the SoldierCrab flash layout.