### PR TITLE
[experiment/nomerge] dynamic resolution switching

### DIFF
--- a/gateware/src/rs/hal/src/dma_display.rs
+++ b/gateware/src/rs/hal/src/dma_display.rs
@@ -1,42 +1,62 @@
+pub trait DMAFramebuffer {
+    fn set_palette_rgb(&mut self, intensity: u8, hue: u8, r: u8, g: u8, b: u8);
+}
+
 #[macro_export]
-macro_rules! impl_dma_display {
+macro_rules! impl_dma_framebuffer {
     ($(
-        $DMA_DISPLAYX:ident, $H_ACTIVE:expr, $V_ACTIVE:expr, $VIDEO_ROTATE_90: expr
+        $DMA_FRAMEBUFFERX:ident: $PACFRAMEBUFFERX:ty,
     )+) => {
         $(
-            struct $DMA_DISPLAYX {
+            struct $DMA_FRAMEBUFFERX {
+                registers: $PACFRAMEBUFFERX,
                 framebuffer_base: *mut u32,
+                h_active: u32,
+                v_active: u32,
+                rotate_90: bool,
             }
 
-            impl OriginDimensions for $DMA_DISPLAYX {
-                fn size(&self) -> Size {
-                    Size::new($H_ACTIVE, $V_ACTIVE)
+            impl hal::dma_display::DMAFramebuffer for $DMA_FRAMEBUFFERX {
+                fn set_palette_rgb(&mut self, intensity: u8, hue: u8, r: u8, g: u8, b: u8)  {
+                    /* wait until last coefficient written */ 
+                    while self.registers.palette_busy().read().bits() == 1 { }
+                    self.registers.palette().write(|w| unsafe {
+                        w.position().bits(((intensity&0xF) << 4) | (hue&0xF));
+                        w.red()     .bits(r);
+                        w.green()   .bits(g);
+                        w.blue()    .bits(b)
+                    } );
                 }
             }
 
-            impl DrawTarget for $DMA_DISPLAYX {
+            impl OriginDimensions for $DMA_FRAMEBUFFERX {
+                fn size(&self) -> Size {
+                    Size::new(self.h_active, self.v_active)
+                }
+            }
+
+            impl DrawTarget for $DMA_FRAMEBUFFERX {
                 type Color = Gray8;
                 type Error = core::convert::Infallible;
                 fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
                 where
                     I: IntoIterator<Item = Pixel<Self::Color>>,
                 {
-                    let xs: u32 = $H_ACTIVE;
-                    let ys: u32 = $V_ACTIVE;
                     for Pixel(coord, color) in pixels.into_iter() {
-                        if let Ok((x @ 0..=$H_ACTIVE,
-                                   y @ 0..=$V_ACTIVE)) = coord.try_into() {
-                            let xf = if $VIDEO_ROTATE_90 {$V_ACTIVE - y} else {x};
-                            let yf = if $VIDEO_ROTATE_90 {x}             else {y};
-                            // Calculate the index in the framebuffer.
-                            let index: u32 = (xf + yf * $H_ACTIVE) / 4;
-                            unsafe {
-                                // TODO: support anything other than Gray8
-                                let mut px = self.framebuffer_base.offset(
-                                    index as isize).read_volatile();
-                                px &= !(0xFFu32 << (8*(xf%4)));
-                                self.framebuffer_base.offset(index as isize).write_volatile(
-                                    px | ((color.luma() as u32) << (8*(xf%4))));
+                        if let Ok((x, y)) = coord.try_into() {
+                            if x >= 0 && x < self.h_active && y >= 0 && y < self.v_active {
+                                let xf: u32 = if self.rotate_90 {self.v_active - y} else {x};
+                                let yf: u32 = if self.rotate_90 {x}             else {y};
+                                // Calculate the index in the framebuffer.
+                                let index: u32 = (xf + yf * self.h_active) / 4;
+                                unsafe {
+                                    // TODO: support anything other than Gray8
+                                    let mut px = self.framebuffer_base.offset(
+                                        index as isize).read_volatile();
+                                    px &= !(0xFFu32 << (8*(xf%4)));
+                                    self.framebuffer_base.offset(index as isize).write_volatile(
+                                        px | ((color.luma() as u32) << (8*(xf%4))));
+                                }
                             }
                         }
                     }

--- a/gateware/src/rs/hal/src/lib.rs
+++ b/gateware/src/rs/hal/src/lib.rs
@@ -7,7 +7,7 @@
 extern crate std;
 
 // modules
-pub mod dma_display;
+pub mod dma_framebuffer;
 pub mod encoder;
 pub mod i2c;
 pub mod pca9635;

--- a/gateware/src/rs/hal/src/video.rs
+++ b/gateware/src/rs/hal/src/video.rs
@@ -1,5 +1,4 @@
 pub trait Video {
-    fn set_palette_rgb(&mut self, intensity: u8, hue: u8, r: u8, g: u8, b: u8);
     fn set_persist(&mut self, value: u16);
     fn set_decay(&mut self, value: u8);
 }
@@ -22,17 +21,6 @@ macro_rules! impl_video {
             }
 
             impl hal::video::Video for $VIDEOX {
-                fn set_palette_rgb(&mut self, intensity: u8, hue: u8, r: u8, g: u8, b: u8)  {
-                    /* wait until last coefficient written */ 
-                    while self.registers.palette_busy().read().bits() == 1 { }
-                    self.registers.palette().write(|w| unsafe {
-                        w.position().bits(((intensity&0xF) << 4) | (hue&0xF));
-                        w.red()     .bits(r);
-                        w.green()   .bits(g);
-                        w.blue()    .bits(b)
-                    } );
-                }
-
                 fn set_persist(&mut self, value: u16)  {
                     self.registers.persist().write(|w| unsafe { w.persist().bits(value) } );
                 }

--- a/gateware/src/rs/lib/src/edid.rs
+++ b/gateware/src/rs/lib/src/edid.rs
@@ -1,0 +1,294 @@
+/// Tiny EDID parser, only handles the header and detailed timing descriptor.
+/// Does not handle extension blocks. This should be enough for most small embedded monitors.
+
+/// Main EDID structure representing the first 128 bytes of an EDID block
+#[derive(Debug)]
+pub struct Edid {
+    // Header (bytes 0-19)
+    pub header: EdidHeader,
+    // Detailed timing descriptors (bytes 54-125)
+    pub descriptors: [Descriptor; 4],
+    // Extension flag (byte 126)
+    pub extensions: u8,
+    // Checksum (byte 127)
+    pub checksum: u8,
+}
+
+/// EDID Header information (bytes 0-19)
+#[derive(Debug)]
+pub struct EdidHeader {
+    // Fixed header pattern (bytes 0-7)
+    pub pattern: [u8; 8],
+    // Manufacturer ID (bytes 8-9)
+    pub manufacturer_id: [u8; 2],
+    // Manufacturer product code (bytes 10-11)
+    pub product_code: u16,
+    // Serial number (bytes 12-15)
+    pub serial_number: u32,
+    // Week of manufacture (byte 16)
+    pub manufacture_week: u8,
+    // Year of manufacture (byte 17)
+    pub manufacture_year: u8,
+    // EDID version & revision (bytes 18-19)
+    pub version: u8,
+    pub revision: u8,
+}
+
+/// Detailed timing descriptors (18 bytes each)
+/// For simplicity, we're just storing the raw data for now
+#[derive(Debug, Copy, Clone)]
+pub struct RawDescriptor {
+    pub data: [u8; 18],
+}
+
+/// Descriptor types for the 18-byte descriptor blocks
+#[derive(Debug, Copy, Clone)]
+pub enum Descriptor {
+    DetailedTiming(DetailedTimingDescriptor),
+    RawDescriptor([u8; 18]),
+}
+
+/// Detailed timing descriptor (used when pixel clock != 0)
+#[derive(Debug, Copy, Clone)]
+pub struct DetailedTimingDescriptor {
+    pub pixel_clock_khz: u32,  // in 10 kHz units
+    pub horizontal_active: u16,
+    pub horizontal_blanking: u16,
+    pub vertical_active: u16,
+    pub vertical_blanking: u16,
+    pub horizontal_sync_offset: u16,
+    pub horizontal_sync_pulse_width: u16,
+    pub vertical_sync_offset: u16,
+    pub vertical_sync_pulse_width: u16,
+    pub horizontal_image_size_mm: u16,
+    pub vertical_image_size_mm: u16,
+    pub horizontal_border: u8,
+    pub vertical_border: u8,
+    pub features: TimingFeatures,
+}
+
+/// Timing features bitmap
+#[derive(Debug, Copy, Clone)]
+pub struct TimingFeatures {
+    pub interlaced: bool,
+    pub stereo_mode: StereoMode,
+    pub sync_type: SyncType,
+}
+
+/// Stereo mode options
+#[derive(Debug, Copy, Clone)]
+pub enum StereoMode {
+    None,
+    FieldSequentialRight,
+    FieldSequentialLeft,
+    InterleavedRightEven,
+    InterleavedLeftEven,
+    FourWayInterleaved,
+    SideBySideInterleaved,
+}
+
+/// Sync type options
+#[derive(Debug, Copy, Clone)]
+pub enum SyncType {
+    Analog {
+        bipolar: bool,
+        serration: bool,
+        sync_on_rgb: bool,
+    },
+    DigitalComposite {
+        serration: bool,
+        hsync_positive: bool,
+    },
+    DigitalSeparate {
+        vsync_positive: bool,
+        hsync_positive: bool,
+    },
+}
+
+impl Edid {
+    /// Parse the EDID from raw bytes
+    pub fn parse(edid_data: &[u8; 128]) -> Result<Self, EdidError> {
+        // Verify checksum
+        let mut checksum: u8 = 0;
+        for &byte in edid_data.iter() {
+            checksum = checksum.wrapping_add(byte);
+        }
+        if checksum != 0 {
+            return Err(EdidError::InvalidChecksum);
+        }
+        // Parse EDID header
+        let header = EdidHeader {
+            pattern: [
+                edid_data[0], edid_data[1], edid_data[2], edid_data[3],
+                edid_data[4], edid_data[5], edid_data[6], edid_data[7],
+            ],
+            manufacturer_id: [edid_data[8], edid_data[9]],
+            product_code: u16::from_le_bytes([edid_data[10], edid_data[11]]),
+            serial_number: u32::from_le_bytes([
+                edid_data[12], edid_data[13], edid_data[14], edid_data[15],
+            ]),
+            manufacture_week: edid_data[16],
+            manufacture_year: edid_data[17],
+            version: edid_data[18],
+            revision: edid_data[19],
+        };
+        // Verify header pattern
+        if header.pattern != [0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00] {
+            return Err(EdidError::InvalidHeaderPattern);
+        }
+        let mut descriptors = [Descriptor::RawDescriptor([0; 18]); 4];
+        for i in 0..4 {
+            let offset = 54 + i * 18;
+            let mut data = [0; 18];
+            data.copy_from_slice(&edid_data[offset..offset + 18]);
+            // Parse the descriptor based on its format
+            descriptors[i] = Self::parse_descriptor(&data);
+        }
+
+        Ok(Edid {
+            header,
+            descriptors,
+            extensions: edid_data[126],
+            checksum: edid_data[127],
+        })
+    }
+
+    /// Parse a descriptor block
+    fn parse_descriptor(data: &[u8; 18]) -> Descriptor {
+        // Check if it's a detailed timing descriptor (pixel clock != 0)
+        let pixel_clock = u16::from_le_bytes([data[0], data[1]]);
+        if pixel_clock != 0 {
+            // Detailed timing descriptor
+            return Descriptor::DetailedTiming(Self::parse_detailed_timing(data));
+        }
+        // It's not a detailed timing descriptor, store raw data
+        Descriptor::RawDescriptor(*data)
+    }
+
+    /// Parse a detailed timing descriptor
+    fn parse_detailed_timing(data: &[u8; 18]) -> DetailedTimingDescriptor {
+        let pixel_clock = u16::from_le_bytes([data[0], data[1]]) as u32 * 10; // 10 kHz units
+                                                                              //
+        // Horizontal active/blanking
+        let h_active = ((data[4] as u16 & 0xF0) << 4) | data[2] as u16;
+        let h_blanking = ((data[4] as u16 & 0x0F) << 8) | data[3] as u16;
+
+        // Vertical active/blanking
+        let v_active = ((data[7] as u16 & 0xF0) << 4) | data[5] as u16;
+        let v_blanking = ((data[7] as u16 & 0x0F) << 8) | data[6] as u16;
+
+        // Sync offsets and pulse widths
+        let h_sync_offset = ((data[11] as u16 & 0xC0) << 2) | data[8] as u16;
+        let h_sync_pulse_width = ((data[11] as u16 & 0x30) << 4) | data[9] as u16;
+        let v_sync_offset = ((data[11] as u16 & 0x0C) << 2) | ((data[10] as u16 & 0xF0) >> 4);
+        let v_sync_pulse_width = ((data[11] as u16 & 0x03) << 4) | (data[10] as u16 & 0x0F);
+
+        // Image size
+        let h_image_size = ((data[14] as u16 & 0xF0) << 4) | data[12] as u16;
+        let v_image_size = ((data[14] as u16 & 0x0F) << 8) | data[13] as u16;
+
+        // Borders
+        let h_border = data[15];
+        let v_border = data[16];
+
+        // Features
+        let interlaced = (data[17] & 0x80) != 0;
+
+        // Stereo mode
+        let stereo_bits = ((data[17] & 0x60) >> 4) | (data[17] & 0x01);
+        let stereo_mode = match stereo_bits {
+            0x00 | 0x01 => StereoMode::None,
+            0x02 => StereoMode::FieldSequentialRight,
+            0x04 => StereoMode::FieldSequentialLeft,
+            0x03 => StereoMode::InterleavedRightEven,
+            0x05 => StereoMode::InterleavedLeftEven,
+            0x06 => StereoMode::FourWayInterleaved,
+            0x07 => StereoMode::SideBySideInterleaved,
+            _ => StereoMode::None, // Should not happen
+        };
+
+        // Sync type
+        let sync_type = match (data[17] >> 3) & 0x03 {
+            0x00 => SyncType::Analog {
+                bipolar: (data[17] & 0x04) != 0,
+                serration: (data[17] & 0x02) != 0,
+                sync_on_rgb: (data[17] & 0x01) != 0,
+            },
+            0x02 => SyncType::DigitalComposite {
+                serration: (data[17] & 0x04) != 0,
+                hsync_positive: (data[17] & 0x02) != 0,
+            },
+            0x03 => SyncType::DigitalSeparate {
+                vsync_positive: (data[17] & 0x04) != 0,
+                hsync_positive: (data[17] & 0x02) != 0,
+            },
+            _ => SyncType::Analog {
+                bipolar: false,
+                serration: false,
+                sync_on_rgb: false,
+            },
+        };
+
+        DetailedTimingDescriptor {
+            pixel_clock_khz: pixel_clock,
+            horizontal_active: h_active,
+            horizontal_blanking: h_blanking,
+            vertical_active: v_active,
+            vertical_blanking: v_blanking,
+            horizontal_sync_offset: h_sync_offset,
+            horizontal_sync_pulse_width: h_sync_pulse_width,
+            vertical_sync_offset: v_sync_offset,
+            vertical_sync_pulse_width: v_sync_pulse_width,
+            horizontal_image_size_mm: h_image_size,
+            vertical_image_size_mm: v_image_size,
+            horizontal_border: h_border,
+            vertical_border: v_border,
+            features: TimingFeatures {
+                interlaced,
+                stereo_mode,
+                sync_type,
+            },
+        }
+    }
+}
+
+/// Error type for EDID parsing
+#[derive(Debug)]
+pub enum EdidError {
+    InvalidChecksum,
+    InvalidHeaderPattern,
+}
+
+// A simple example of how to use the parser
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_edid_parse() {
+        // Example EDID data from Tiliqua screen
+        let edid_data = [
+            0x0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x0,
+            0xff, 0xff, 0x32, 0x31, 0x45, 0x6, 0x0, 0x0,
+            0xc, 0x1c, 0x1, 0x3, 0x80, 0xf, 0xa, 0x78,
+            0xa, 0xd, 0xc9, 0xa0, 0x57, 0x47, 0x98, 0x27,
+            0x12, 0x48, 0x4c, 0x0, 0x0, 0x0, 0x1, 0xc1,
+            0x1, 0x1, 0x1, 0xc1, 0x1, 0x1, 0x1, 0x1,
+            0x1, 0x1, 0x1, 0x1, 0x1, 0x1, 0x9b, 0xe,
+            0xd0, 0x64, 0x20, 0xd0, 0x28, 0x20, 0x28, 0x14,
+            0x84, 0x4, 0xd0, 0xd0, 0x22, 0x0, 0x0, 0x1e,
+            0x9c, 0xe, 0xd0, 0x64, 0x20, 0xd0, 0x28, 0x20,
+            0x14, 0x28, 0x48, 0x1, 0x5, 0x28, 0x0, 0x20,
+            0x20, 0x20, 0x0, 0x0, 0x0, 0xfa, 0x0, 0xa,
+            0x20, 0x20, 0x20, 0x20, 0x2, 0x0, 0x20, 0x20,
+            0x20, 0x20, 0x20, 0xa, 0x0, 0x0, 0x0, 0xfc,
+            0x0, 0x5a, 0x4c, 0x37, 0x32, 0x30, 0x58, 0x37,
+            0x32, 0x30, 0xa, 0x20, 0x20, 0x20, 0x1, 0x62,
+        ];
+
+        let edid = Edid::parse(&edid_data);
+        match edid {
+            Ok(data) => println!("Successfully parsed EDID: {:#?}", data),
+            Err(e) => panic!("Failed to parse EDID: {:?}", e),
+        }
+    }
+}

--- a/gateware/src/rs/lib/src/lib.rs
+++ b/gateware/src/rs/lib/src/lib.rs
@@ -10,3 +10,4 @@ pub mod ui;
 pub mod dsp;
 pub mod midi;
 pub mod calibration;
+pub mod edid;

--- a/gateware/src/rs/lib/src/palette.rs
+++ b/gateware/src/rs/lib/src/palette.rs
@@ -1,4 +1,4 @@
-use tiliqua_hal::dma_display::DMAFramebuffer;
+use tiliqua_hal::dma_framebuffer::DMAFramebuffer;
 
 use strum_macros::{EnumIter, IntoStaticStr};
 

--- a/gateware/src/rs/lib/src/palette.rs
+++ b/gateware/src/rs/lib/src/palette.rs
@@ -1,4 +1,4 @@
-use tiliqua_hal::video::Video;
+use tiliqua_hal::dma_display::DMAFramebuffer;
 
 use strum_macros::{EnumIter, IntoStaticStr};
 
@@ -100,7 +100,7 @@ impl ColorPalette {
         }
     }
 
-    pub fn write_to_hardware(&self, video: &mut impl Video) {
+    pub fn write_to_hardware(&self, video: &mut impl DMAFramebuffer) {
         for i in 0..PX_INTENSITY_MAX {
             for h in 0..PX_HUE_MAX {
                 let rgb = self.compute_color(i, h);

--- a/gateware/src/tiliqua/dma_framebuffer.py
+++ b/gateware/src/tiliqua/dma_framebuffer.py
@@ -111,12 +111,16 @@ class DMAFramebuffer(wiring.Component):
 
         fb_size_words = (self.timings.active_pixels * self.bytes_per_pixel) // 4
 
+
+        tgen_en = Signal()
+        m.submodules.en_ff = FFSynchronizer(
+                i=tgen_en, o=dvi_tgen.enable, o_domain="dvi")
         # Read to FIFO in sync domain
         with m.FSM() as fsm:
             with m.State('OFF'):
                 with m.If(self.enable):
                     # TODO FFsync
-                    m.d.dvi += dvi_tgen.enable.eq(1)
+                    m.d.sync += tgen_en.eq(1)
                     m.next = 'BURST'
             with m.State('BURST'):
                 m.d.comb += [

--- a/gateware/src/tiliqua/dma_framebuffer.py
+++ b/gateware/src/tiliqua/dma_framebuffer.py
@@ -115,6 +115,8 @@ class DMAFramebuffer(wiring.Component):
         with m.FSM() as fsm:
             with m.State('OFF'):
                 with m.If(self.enable):
+                    # TODO FFsync
+                    m.d.dvi += dvi_tgen.enable.eq(1)
                     m.next = 'BURST'
             with m.State('BURST'):
                 m.d.comb += [
@@ -287,7 +289,6 @@ class Peripheral(wiring.Component):
         with m.If(self._hv_timing.element.w_stb):
             m.d.sync += self.fb.timings.h_sync_invert.eq(self._hv_timing.f.h_sync_invert.w_data)
             m.d.sync += self.fb.timings.v_sync_invert.eq(self._hv_timing.f.v_sync_invert.w_data)
-        with m.If(self._hv_timing.f.active_pixels.w_stb):
             m.d.sync += self.fb.timings.active_pixels.eq(self._hv_timing.f.active_pixels.w_data)
         with m.If(self._flags.f.enable.w_stb):
             m.d.sync += self.fb.enable.eq(self._flags.f.enable.w_data)

--- a/gateware/src/tiliqua/dvi.py
+++ b/gateware/src/tiliqua/dvi.py
@@ -9,6 +9,7 @@ from amaranth.lib import wiring
 from amaranth.lib.wiring import In, Out
 
 from tiliqua import sim, tmds
+from tiliqua.dvi_modeline  import DVIModeline
 
 class DVITimingGen(wiring.Component):
 

--- a/gateware/src/tiliqua/dvi.py
+++ b/gateware/src/tiliqua/dvi.py
@@ -51,6 +51,7 @@ class DVITimingGen(wiring.Component):
 
     def __init__(self):
         super().__init__({
+            "enable": In(1),
             "timings": In(self.TimingProperties()),
             # Control signals without inversion applied.
             # Useful for driving logic external to this core (e.g. do something
@@ -79,7 +80,7 @@ class DVITimingGen(wiring.Component):
         self.x = Signal(signed(12))
         self.y = Signal(signed(12))
 
-        with m.If(ResetSignal("dvi")):
+        with m.If(ResetSignal("dvi") | ~self.enable):
             m.d.dvi += [
                 self.x.eq(self.h_reset),
                 self.y.eq(self.v_reset),

--- a/gateware/src/tiliqua/tiliqua_platform.py
+++ b/gateware/src/tiliqua/tiliqua_platform.py
@@ -322,10 +322,28 @@ class _TiliquaR4Mobo:
                                       Attrs(IO_TYPE="LVCMOS33"))),
 
         # Motherboard PCBA I2C bus. Includes:
+        #
         # - address 0x05: PCA9635 LED driver
         # - address 0x47: TUSB322I USB-C controller
         # - address 0x50: DVI EDID EEPROM (through 3V3 <-> 5V translator)
         # - address 0x60: SI5351A external PLL
+        #
+        # WARN: mobo i2c bus speed should never exceed 100kHz if you want to reliably
+        # be able to read the EDID of external monitors. I have seen cases where going
+        # above 100kHz causes the monitor to ACK packets that were not destined for
+        # its EEPROM (instead for other i2c peripherals on i2c0) - this is dangerous and
+        # could unintentionally write to the monitor EEPROM (!!!)
+        #
+        # There are some slave addresses on the DDC channel that are reserved according
+        # to the standard. As far as I can tell, we have no collisions. Reference:
+        #
+        #   VESA Display Data Channel Command Interface (DDC/CI)
+        #   Standard Version 1.1, October 29, 2004
+        #
+        # Reserved for VCP: 0x6E
+        # Reserved in table 4: 0xF0 - 0xFF
+        # Reserved in table 5: 0x12, 0x14, 0x16, 0x80, 0x40, 0xA0
+        #
         Resource("i2c", 0,
             Subsignal("sda", Pins("51", dir="io", conn=("m2", 0))),
             Subsignal("scl", Pins("53", dir="io", conn=("m2", 0))),

--- a/gateware/src/tiliqua/tiliqua_soc.py
+++ b/gateware/src/tiliqua/tiliqua_soc.py
@@ -221,7 +221,9 @@ class TiliquaSoc(Component):
 
         # mobo i2c
         self.i2c0 = i2c.Peripheral()
-        self.i2c_stream0 = i2c.I2CStreamer(period_cyc=256)
+        # XXX: 100kHz bus speed. DO NOT INCREASE THIS. See comment on this bus in
+        # tiliqua_platform.py for more details.
+        self.i2c_stream0 = i2c.I2CStreamer(period_cyc=600)
         self.csr_decoder.add(self.i2c0.bus, addr=self.i2c0_base, name="i2c0")
 
         # eurorack-pmod i2c

--- a/gateware/src/tiliqua/tiliqua_soc.py
+++ b/gateware/src/tiliqua/tiliqua_soc.py
@@ -139,6 +139,7 @@ class TiliquaSoc(Component):
         self.pmod0_periph_base    = 0x00000700
         self.dtr0_base            = 0x00000800
         self.video_periph_base    = 0x00000900
+        self.framebuffer_periph_base       = 0x00000A00
 
         # Some settings depend on whether code is in block RAM or SPI flash
         self.fw_location = fw_location
@@ -250,6 +251,10 @@ class TiliquaSoc(Component):
             bus_dma=self.psram_periph)
         self.csr_decoder.add(self.video_periph.bus, addr=self.video_periph_base, name="video_periph")
 
+        self.framebuffer_periph = dma_framebuffer.Peripheral(fb=self.fb)
+        self.csr_decoder.add(
+                self.framebuffer_periph.bus, addr=self.framebuffer_periph_base, name="framebuffer_periph")
+
         self.permit_bus_traffic = Signal()
 
         self.extra_rust_constants = []
@@ -338,6 +343,7 @@ class TiliquaSoc(Component):
 
         # video PHY
         m.submodules.fb = self.fb
+        m.submodules.framebuffer_periph = self.framebuffer_periph
 
         # video periph / persist
         m.submodules.video_periph = self.video_periph
@@ -381,7 +387,6 @@ class TiliquaSoc(Component):
             m.d.sync += on_delay.eq(on_delay+1)
         with m.Else():
             m.d.sync += self.permit_bus_traffic.eq(1)
-            m.d.sync += self.fb.enable.eq(1)
             m.d.sync += self.video_periph.en.eq(1)
 
         return m

--- a/gateware/src/tiliqua/tiliqua_soc.py
+++ b/gateware/src/tiliqua/tiliqua_soc.py
@@ -90,7 +90,7 @@ class VideoPeripheral(wiring.Component):
 
         connect(m, flipped(self.bus), self._bridge.bus)
 
-        m.d.comb += self.persist.enable.eq(self.en)
+        m.d.comb += self.persist.enable.eq(self.fb.enable)
 
         with m.If(self._persist.f.persist.w_stb):
             m.d.sync += self.persist.holdoff.eq(self._persist.f.persist.w_data)
@@ -382,12 +382,10 @@ class TiliquaSoc(Component):
         # Memory controller hangs if we start making requests to it straight away.
         on_delay = Signal(32)
         with m.If(on_delay < 0xFF):
-            m.d.comb += self.cpu.ext_reset.eq(1)
-        with m.If(on_delay < 0xFFFF):
             m.d.sync += on_delay.eq(on_delay+1)
+            m.d.comb += self.cpu.ext_reset.eq(1)
         with m.Else():
-            m.d.sync += self.permit_bus_traffic.eq(1)
-            m.d.sync += self.video_periph.en.eq(1)
+            m.d.comb += self.cpu.ext_reset.eq(0)
 
         return m
 

--- a/gateware/src/top/bootloader/fw/src/main.rs
+++ b/gateware/src/top/bootloader/fw/src/main.rs
@@ -35,8 +35,9 @@ use embedded_graphics::{
 use tiliqua_fw::options::*;
 use hal::pca9635::Pca9635Driver;
 
-hal::impl_dma_display!(DMADisplay, H_ACTIVE, V_ACTIVE,
-                       VIDEO_ROTATE_90);
+tiliqua_hal::impl_dma_framebuffer! {
+    DMAFramebuffer0: tiliqua_pac::FRAMEBUFFER_PERIPH,
+}
 
 pub const TIMER0_ISR_PERIOD_MS: u32 = 10;
 
@@ -511,8 +512,12 @@ fn main() -> ! {
 
         let mut logo_coord_ix = 0u32;
         let mut rng = fastrand::Rng::with_seed(0);
-        let mut display = DMADisplay {
+        let mut display = DMAFramebuffer0 {
+            registers: peripherals.FRAMEBUFFER_PERIPH,
             framebuffer_base: PSRAM_FB_BASE as *mut u32,
+            h_active: H_ACTIVE,
+            v_active: V_ACTIVE,
+            rotate_90: VIDEO_ROTATE_90,
         };
         video.set_persist(1024);
 
@@ -521,7 +526,7 @@ fn main() -> ! {
             .stroke_width(1)
             .build();
 
-        palette::ColorPalette::default().write_to_hardware(&mut video);
+        palette::ColorPalette::default().write_to_hardware(&mut display);
 
         log::info!("{}", startup_report);
 

--- a/gateware/src/top/bootloader/fw/src/main.rs
+++ b/gateware/src/top/bootloader/fw/src/main.rs
@@ -512,13 +512,29 @@ fn main() -> ! {
 
         let mut logo_coord_ix = 0u32;
         let mut rng = fastrand::Rng::with_seed(0);
-        let mut display = DMAFramebuffer0 {
-            registers: peripherals.FRAMEBUFFER_PERIPH,
-            framebuffer_base: PSRAM_FB_BASE as *mut u32,
-            h_active: H_ACTIVE,
-            v_active: V_ACTIVE,
-            rotate_90: VIDEO_ROTATE_90,
-        };
+
+        let mut display = DMAFramebuffer0::new(
+            peripherals.FRAMEBUFFER_PERIPH,
+            PSRAM_FB_BASE,
+            DVIModeline {
+                h_active      : 1280,
+                h_sync_start  : 1390,
+                h_sync_end    : 1430,
+                h_total       : 1650,
+                h_sync_invert : false,
+                v_active      : 720,
+                v_sync_start  : 725,
+                v_sync_end    : 730,
+                v_total       : 750,
+                v_sync_invert : false,
+                pixel_clk_mhz : 74.25,
+            },
+            VIDEO_ROTATE_90,
+        );
+
+        info!("display configured for {}x{}",
+              display.size().width, display.size().height);
+
         video.set_persist(1024);
 
         let stroke = PrimitiveStyleBuilder::new()
@@ -532,8 +548,8 @@ fn main() -> ! {
 
         loop {
 
-            let h_active = display.h_active.clone();
-            let v_active = display.v_active.clone();
+            let h_active = display.size().width;
+            let v_active = display.size().height;
 
             // Always mute the CODEC to stop pops on flashing while in the bootloader.
             pmod.mute(true);

--- a/gateware/src/top/bootloader/fw/src/main.rs
+++ b/gateware/src/top/bootloader/fw/src/main.rs
@@ -532,6 +532,9 @@ fn main() -> ! {
 
         loop {
 
+            let h_active = display.h_active.clone();
+            let v_active = display.v_active.clone();
+
             // Always mute the CODEC to stop pops on flashing while in the bootloader.
             pmod.mute(true);
 
@@ -541,14 +544,14 @@ fn main() -> ! {
                  app.borrow_ref(cs).error_n.clone())
             });
 
-            draw::draw_options(&mut display, &opts, 100, V_ACTIVE/2-50, 0).ok();
-            draw::draw_name(&mut display, H_ACTIVE/2, V_ACTIVE-50, 0, UI_NAME, UI_SHA).ok();
+            draw::draw_options(&mut display, &opts, 100, v_active/2-50, 0).ok();
+            draw::draw_name(&mut display, h_active/2, v_active-50, 0, UI_NAME, UI_SHA).ok();
 
             if let Some(n) = opts.tracker.selected {
                 draw_summary(&mut display, &manifests[n], &error_n[n], &startup_report, -20, -18, 0);
                 if manifests[n].is_some() {
-                    Line::new(Point::new(255, (V_ACTIVE/2 - 55 + (n as u32)*18) as i32),
-                              Point::new((H_ACTIVE/2-90) as i32, (V_ACTIVE/2+8) as i32))
+                    Line::new(Point::new(255, (v_active/2 - 55 + (n as u32)*18) as i32),
+                              Point::new((h_active/2-90) as i32, (v_active/2+8) as i32))
                               .into_styled(stroke)
                               .draw(&mut display).ok();
                 }
@@ -556,7 +559,7 @@ fn main() -> ! {
 
             for _ in 0..5 {
                 let _ = draw::draw_boot_logo(&mut display,
-                                             (H_ACTIVE/2) as i32,
+                                             (h_active/2) as i32,
                                              150 as i32,
                                              logo_coord_ix);
                 logo_coord_ix += 1;


### PR DESCRIPTION
NOMERGE (work-in-progress)

Read display EDID when bootloader starts, to determine attached screen resolution. At the moment we only detect 720x720 (bundled Tiliqua screen), and if this is not available, switch to 1280x720 (supported by most monitors).

Changes:
- Add SoC peripheral to allow CPU to dynamically configure video timings used by the DVI serializer
- Add tiny EDID parser used by the bootloader to determine attached display capabilities
- Modify draw libraries to take dynamic h/v width so we can dynamically scale