### PR TITLE
leds: dim all LEDs to 25%

### DIFF
--- a/gateware/src/rs/hal/src/pca9635.rs
+++ b/gateware/src/rs/hal/src/pca9635.rs
@@ -40,12 +40,12 @@ impl<I2C: I2c> Pca9635<I2C> for Pca9635Driver<I2C> {
            self.leds[0xD], // PWM13
            self.leds[0xE], // PWM14
            self.leds[0xF], // PWM15
-           0xFFu8, // GRPPWM
+           0x40u8, // GRPPWM
            0x00u8, // GRPFREQ
-           0xAAu8, // LEDOUT0
-           0xAAu8, // LEDOUT1
-           0xAAu8, // LEDOUT2
-           0xAAu8, // LEDOUT3
+           0xFFu8, // LEDOUT0
+           0xFFu8, // LEDOUT1
+           0xFFu8, // LEDOUT2
+           0xFFu8, // LEDOUT3
         ];
         self.i2c.transaction(PCA9635_ADDR, &mut [Operation::Write(&pca9635_bytes)])
     }

--- a/gateware/src/tiliqua/eurorack_pmod.py
+++ b/gateware/src/tiliqua/eurorack_pmod.py
@@ -431,12 +431,12 @@ class I2CMaster(wiring.Component):
         0x10, # PWM13
         0x10, # PWM14
         0x10, # PWM15
-        0xFF, # GRPPWM
+        0x80, # GRPPWM
         0x00, # GRPFREQ
-        0xAA, # LEDOUT0
-        0xAA, # LEDOUT1
-        0xAA, # LEDOUT2
-        0xAA, # LEDOUT3
+        0xFF, # LEDOUT0
+        0xFF, # LEDOUT1
+        0xFF, # LEDOUT2
+        0xFF, # LEDOUT3
     ]
 
     def __init__(self, audio_192):

--- a/gateware/src/tiliqua/eurorack_pmod.py
+++ b/gateware/src/tiliqua/eurorack_pmod.py
@@ -431,7 +431,7 @@ class I2CMaster(wiring.Component):
         0x10, # PWM13
         0x10, # PWM14
         0x10, # PWM15
-        0x80, # GRPPWM
+        0x40, # GRPPWM
         0x00, # GRPFREQ
         0xFF, # LEDOUT0
         0xFF, # LEDOUT1


### PR DESCRIPTION
- Dimming them reduces current consumption and improves v/oct tracking a bit.