### PR TITLE
dma_framebuffer/psram_periph: improve framebuffer stability, add CSRs for psram bandwidth monitoring

### DIFF
--- a/gateware/src/tiliqua/dma_framebuffer.py
+++ b/gateware/src/tiliqua/dma_framebuffer.py
@@ -90,26 +90,16 @@ class DMAFramebuffer(wiring.Component):
         phy_vsync_sync = Signal()
         m.submodules.vsync_ff = FFSynchronizer(
                 i=dvi_tgen.ctrl.vsync, o=phy_vsync_sync, o_domain="sync")
-        phy_vsync_sync_prev = Signal()
-        vsync_rise = Signal()
-        m.d.sync += phy_vsync_sync_prev.eq(phy_vsync_sync)
-        m.d.comb += vsync_rise.eq(phy_vsync_sync & ~phy_vsync_sync_prev)
 
         # DMA master bus
         bus = self.bus
 
         # Current offset into the framebuffer
         dma_addr = Signal(32)
+        burst_cnt = Signal(16, init=0)
 
         # DMA bus master -> FIFO state machine
         # Burst until FIFO is full, then wait until half empty.
-
-        # Signal from 'dvi' to 'sync' domain to drain FIFO if we are in vsync.
-        drain_fifo = Signal(1, reset=0)
-        drain_fifo_dvi = Signal(1, reset=0)
-        m.submodules.drain_fifo_ff = FFSynchronizer(
-                i=drain_fifo, o=drain_fifo_dvi, o_domain="dvi")
-        drained = Signal()
 
         fb_size_words = (self.timings.active_pixels * self.bytes_per_pixel) // 4
 
@@ -117,7 +107,11 @@ class DMAFramebuffer(wiring.Component):
         with m.FSM() as fsm:
             with m.State('OFF'):
                 with m.If(self.enable):
-                    m.next = 'BURST'
+                    m.next = 'WAIT-VSYNC'
+            with m.State('WAIT-VSYNC'):
+                with m.If(phy_vsync_sync):
+                    m.d.sync += dma_addr.eq(0)
+                    m.next = 'WAIT'
             with m.State('BURST'):
                 m.d.comb += [
                     bus.stb.eq(1),
@@ -130,26 +124,27 @@ class DMAFramebuffer(wiring.Component):
                     bus.cti.eq(
                         wishbone.CycleType.INCR_BURST),
                 ]
-                with m.If(fifo.w_level >= (self.fifo_depth-1)):
+
+                with m.If(bus.ack):
+                    m.d.sync += [
+                        burst_cnt.eq(burst_cnt + 1),
+                        dma_addr.eq(dma_addr+1),
+                    ]
+
+                with m.If((fifo.w_level == (self.fifo_depth-1)) |
+                          (burst_cnt == self.burst_threshold_words)):
                     m.d.comb += bus.cti.eq(
                             wishbone.CycleType.END_OF_BURST)
-                with m.If(bus.stb & bus.ack & fifo.w_rdy):
-                    with m.If(dma_addr < (fb_size_words-1)):
-                        m.d.sync += dma_addr.eq(dma_addr + 1)
-                    with m.Else():
-                        m.d.sync += dma_addr.eq(0)
-                with m.Elif(~fifo.w_rdy):
                     m.next = 'WAIT'
+
+                with m.If(dma_addr == (fb_size_words-1)):
+                    m.d.comb += bus.cti.eq(
+                            wishbone.CycleType.END_OF_BURST)
+                    m.next = 'WAIT-VSYNC'
+
             with m.State('WAIT'):
-                with m.If(vsync_rise):
-                    m.next = 'VSYNC'
-                with m.Elif(fifo.w_level < self.fifo_depth-self.burst_threshold_words):
-                    m.next = 'BURST'
-            with m.State('VSYNC'):
-                # drain DVI side. We only want to drain once.
-                m.d.comb += drain_fifo.eq(1)
-                with m.If(fifo.w_level == 0):
-                    m.d.sync += dma_addr.eq(0)
+                with m.If(fifo.w_level < self.fifo_depth-self.burst_threshold_words):
+                    m.d.sync += burst_cnt.eq(0)
                     m.next = 'BURST'
 
         # Tracking in DVI domain
@@ -157,9 +152,8 @@ class DMAFramebuffer(wiring.Component):
         # 'dvi' domain: read FIFO -> DVI PHY (1 fifo word is N pixels)
         bytecounter = Signal(exact_log2(4//self.bytes_per_pixel))
         last_word   = Signal(32)
-        with m.If(drain_fifo_dvi):
+        with m.If(dvi_tgen.ctrl.vsync):
             m.d.dvi += bytecounter.eq(0)
-            m.d.comb += fifo.r_en.eq(1),
         with m.Elif(dvi_tgen.ctrl.de & fifo.r_rdy):
             m.d.comb += fifo.r_en.eq(bytecounter == 0),
             m.d.dvi += bytecounter.eq(bytecounter+1)

--- a/gateware/src/tiliqua/psram_peripheral.py
+++ b/gateware/src/tiliqua/psram_peripheral.py
@@ -10,7 +10,7 @@ from amaranth.lib         import wiring
 from amaranth.lib.wiring  import In, flipped
 from amaranth.utils       import exact_log2
 
-from amaranth_soc         import wishbone
+from amaranth_soc         import wishbone, csr
 from amaranth_soc.memory  import MemoryMap
 
 from vendor.psram_ospi    import OSPIPSRAM
@@ -31,6 +31,21 @@ class Peripheral(wiring.Component):
     as a memory region, in the future "psram" might also be acceptable.
     """
 
+    class PsramStatsCtrl(csr.Register, access="w"):
+        collect:        csr.Field(csr.action.W, unsigned(1))
+
+    class PsramStatsReg0(csr.Register, access="r"):
+        cycles_elapsed: csr.Field(csr.action.R, unsigned(32))
+
+    class PsramStatsReg1(csr.Register, access="r"):
+        cycles_idle:    csr.Field(csr.action.R, unsigned(32))
+
+    class PsramStatsReg2(csr.Register, access="r"):
+        cycles_ack_r:   csr.Field(csr.action.R, unsigned(32))
+
+    class PsramStatsReg3(csr.Register, access="r"):
+        cycles_ack_w:   csr.Field(csr.action.R, unsigned(32))
+
     def __init__(self, *, size, data_width=32, granularity=8, name="psram"):
         if not isinstance(size, int) or size <= 0 or size & size-1:
             raise ValueError("Size must be an integer power of two, not {!r}"
@@ -49,8 +64,18 @@ class Peripheral(wiring.Component):
         memory_map = MemoryMap(addr_width=exact_log2(size), data_width=granularity)
         memory_map.add_resource(name=("memory", self.name,), size=size, resource=self)
 
+        # csrs
+        regs = csr.Builder(addr_width=5, data_width=8)
+        self._ctrl   = regs.add("ctrl",   self.PsramStatsCtrl(), offset=0x0)
+        self._stats0 = regs.add("stats0", self.PsramStatsReg0(), offset=0x4)
+        self._stats1 = regs.add("stats1", self.PsramStatsReg1(), offset=0x8)
+        self._stats2 = regs.add("stats2", self.PsramStatsReg2(), offset=0xC)
+        self._stats3 = regs.add("stats3", self.PsramStatsReg3(), offset=0x10)
+        self._bridge = csr.Bridge(regs.as_memory_map())
+
         # bus
         super().__init__({
+            "csr_bus": In(csr.Signature(addr_width=regs.addr_width, data_width=regs.data_width)),
             "bus": In(wishbone.Signature(addr_width=exact_log2(self.mem_depth),
                                          data_width=data_width,
                                          granularity=granularity,
@@ -59,6 +84,7 @@ class Peripheral(wiring.Component):
             # should be optimized out in non-sim builds.
             "simif": In(sim.FakePSRAMSimulationInterface())
         })
+        self.csr_bus.memory_map = self._bridge.bus.memory_map
         self.bus.memory_map = memory_map
 
         # hram arbiter
@@ -68,12 +94,18 @@ class Peripheral(wiring.Component):
                                               features={"cti", "bte"})
         self._hram_arbiter.add(flipped(self.bus))
         self.shared_bus = self._hram_arbiter.bus
+        self.dma_masters = []
 
     def add_master(self, bus):
+        self.dma_masters.append(bus)
         self._hram_arbiter.add(bus)
 
     def elaborate(self, platform):
         m = Module()
+
+        # csr bus
+        m.submodules.bridge = self._bridge
+        wiring.connect(m, wiring.flipped(self.csr_bus), self._bridge.bus)
 
         # arbiter
         m.submodules.arbiter = self._hram_arbiter
@@ -122,6 +154,28 @@ class Peripheral(wiring.Component):
             psram.start_transfer         .eq(0),
             psram.perform_write          .eq(0),
         ]
+
+        stats_collect = Signal()
+
+        with m.If(stats_collect):
+            m.d.sync += self._stats0.f.cycles_elapsed.r_data.eq(self._stats0.f.cycles_elapsed.r_data+1)
+            with m.If(psram.idle):
+                m.d.sync += self._stats1.f.cycles_idle.r_data.eq(self._stats1.f.cycles_idle.r_data+1)
+            with m.If(psram.read_ready):
+                m.d.sync += self._stats2.f.cycles_ack_r.r_data.eq(self._stats2.f.cycles_ack_r.r_data+1)
+            with m.If(psram.write_ready):
+                m.d.sync += self._stats3.f.cycles_ack_w.r_data.eq(self._stats3.f.cycles_ack_w.r_data+1)
+
+        with m.If(self._ctrl.f.collect.w_stb):
+            m.d.sync += stats_collect.eq(self._ctrl.f.collect.w_data)
+            # Reset stats whenever collect is strobed with 1
+            with m.If(self._ctrl.f.collect.w_data):
+                m.d.sync += [
+                    self._stats0.f.cycles_elapsed.r_data.eq(0),
+                    self._stats1.f.cycles_idle.r_data.eq(0),
+                    self._stats2.f.cycles_ack_r.r_data.eq(0),
+                    self._stats3.f.cycles_ack_w.r_data.eq(0),
+                ]
 
         with m.FSM() as fsm:
 

--- a/gateware/src/tiliqua/tiliqua_soc.py
+++ b/gateware/src/tiliqua/tiliqua_soc.py
@@ -173,6 +173,7 @@ class TiliquaSoc(Component):
         self.pmod0_periph_base    = 0x00000700
         self.dtr0_base            = 0x00000800
         self.video_periph_base    = 0x00000900
+        self.psram_csr_base       = 0x00000A00
 
         # Some settings depend on whether code is in block RAM or SPI flash
         self.fw_location = fw_location
@@ -251,6 +252,7 @@ class TiliquaSoc(Component):
         self.fb = dma_framebuffer.DMAFramebuffer(
                 fb_base_default=self.psram_base, fixed_modeline=default_modeline)
         self.psram_periph.add_master(self.fb.bus)
+        self.csr_decoder.add(self.psram_periph.csr_bus, addr=self.psram_csr_base, name="psram_csr")
 
         # mobo i2c
         self.i2c0 = i2c.Peripheral()

--- a/gateware/src/top/macro_osc/fw/src/main.rs
+++ b/gateware/src/top/macro_osc/fw/src/main.rs
@@ -248,8 +248,6 @@ fn main() -> ! {
 
     handler!(timer0 = || timer0_handler(&app));
 
-    let psram = peripherals.PSRAM_CSR;
-
     irq::scope(|s| {
 
         s.register(handlers::Interrupt::TIMER0, timer0);
@@ -293,32 +291,6 @@ fn main() -> ! {
                 draw::draw_name(&mut display, H_ACTIVE/2, V_ACTIVE-50, opts.beam.hue.value, UI_NAME, UI_SHA).ok();
             }
 
-            use heapless::String;
-            use core::fmt::Write;
-            let mut status_report: String<128> = String::new();
-            psram.ctrl().write(|w| w.collect().bit(false));
-            let cycles_elapsed: u32 = psram.stats0().read().cycles_elapsed().bits();
-            let cycles_idle: u32 = psram.stats1().read().cycles_idle().bits();
-            let cycles_ack_r: u32 = psram.stats2().read().cycles_ack_r().bits();
-            let cycles_ack_w: u32 = psram.stats3().read().cycles_ack_w().bits();
-            psram.ctrl().write(|w| w.collect().bit(true));
-            write!(&mut status_report,
-                   "psram [usage={:.2}, ack_r={:.2}, ack_w={:.2}]",
-                   1.0f32 - (cycles_idle as f32 / cycles_elapsed as f32),
-                   cycles_ack_r as f32 / cycles_elapsed as f32,
-                   cycles_ack_w as f32 / cycles_elapsed as f32);
-
-            use embedded_graphics::text::Text;
-            use embedded_graphics::mono_font::ascii::FONT_9X15;
-            use embedded_graphics::text::Alignment;
-            use embedded_graphics::mono_font::MonoTextStyle;
-            let font_small_grey = MonoTextStyle::new(&FONT_9X15, Gray8::new(0xF0));
-            Text::with_alignment(
-                &status_report,
-                Point::new((H_ACTIVE/2) as i32, 100i32),
-                font_small_grey,
-                Alignment::Center
-            ).draw(&mut display);
             video.set_persist(opts.beam.persist.value);
             video.set_decay(opts.beam.decay.value);
 

--- a/gateware/src/top/macro_osc/fw/src/main.rs
+++ b/gateware/src/top/macro_osc/fw/src/main.rs
@@ -248,6 +248,8 @@ fn main() -> ! {
 
     handler!(timer0 = || timer0_handler(&app));
 
+    let psram = peripherals.PSRAM_CSR;
+
     irq::scope(|s| {
 
         s.register(handlers::Interrupt::TIMER0, timer0);
@@ -291,6 +293,32 @@ fn main() -> ! {
                 draw::draw_name(&mut display, H_ACTIVE/2, V_ACTIVE-50, opts.beam.hue.value, UI_NAME, UI_SHA).ok();
             }
 
+            use heapless::String;
+            use core::fmt::Write;
+            let mut status_report: String<128> = String::new();
+            psram.ctrl().write(|w| w.collect().bit(false));
+            let cycles_elapsed: u32 = psram.stats0().read().cycles_elapsed().bits();
+            let cycles_idle: u32 = psram.stats1().read().cycles_idle().bits();
+            let cycles_ack_r: u32 = psram.stats2().read().cycles_ack_r().bits();
+            let cycles_ack_w: u32 = psram.stats3().read().cycles_ack_w().bits();
+            psram.ctrl().write(|w| w.collect().bit(true));
+            write!(&mut status_report,
+                   "psram [usage={:.2}, ack_r={:.2}, ack_w={:.2}]",
+                   1.0f32 - (cycles_idle as f32 / cycles_elapsed as f32),
+                   cycles_ack_r as f32 / cycles_elapsed as f32,
+                   cycles_ack_w as f32 / cycles_elapsed as f32);
+
+            use embedded_graphics::text::Text;
+            use embedded_graphics::mono_font::ascii::FONT_9X15;
+            use embedded_graphics::text::Alignment;
+            use embedded_graphics::mono_font::MonoTextStyle;
+            let font_small_grey = MonoTextStyle::new(&FONT_9X15, Gray8::new(0xF0));
+            Text::with_alignment(
+                &status_report,
+                Point::new((H_ACTIVE/2) as i32, 100i32),
+                font_small_grey,
+                Alignment::Center
+            ).draw(&mut display);
             video.set_persist(opts.beam.persist.value);
             video.set_decay(opts.beam.decay.value);
 

--- a/gateware/src/top/selftest/fw/src/main.rs
+++ b/gateware/src/top/selftest/fw/src/main.rs
@@ -294,6 +294,25 @@ fn print_die_temperature(s: &mut ReportString, dtr: &pac::DTR0)
            code_to_celsius[code as usize]).ok();
 }
 
+fn print_psram_stats(s: &mut ReportString, psram: &pac::PSRAM_CSR)
+{
+    psram.ctrl().write(|w| w.collect().bit(false));
+    let cycles_elapsed: u32 = psram.stats0().read().cycles_elapsed().bits();
+    let cycles_idle: u32 = psram.stats1().read().cycles_idle().bits();
+    let cycles_ack_r: u32 = psram.stats2().read().cycles_ack_r().bits();
+    let cycles_ack_w: u32 = psram.stats3().read().cycles_ack_w().bits();
+    psram.ctrl().write(|w| w.collect().bit(true));
+    let sysclk = pac::clock::sysclk();
+    write!(s,
+           concat!("psram [busy={}%, wasted={}%, read={}%,\r\n",
+                   "       write={}%, refresh={}Hz]\r\n"),
+           (100.0f32 * (1.0f32 - (cycles_idle as f32 / cycles_elapsed as f32))) as u32,
+           (100.0f32 * (cycles_elapsed - cycles_idle - cycles_ack_r - cycles_ack_w) as f32 / cycles_elapsed as f32) as u32,
+           (100.0f32 * cycles_ack_r as f32 / cycles_elapsed as f32) as u32,
+           (100.0f32 * cycles_ack_w as f32 / cycles_elapsed as f32) as u32,
+           sysclk / (cycles_elapsed+1)).ok();
+}
+
 struct App {
     ui: ui::UI<Encoder0, EurorackPmod0, I2c0, Opts>,
 }
@@ -420,18 +439,7 @@ fn main() -> ! {
                         print_pmod_state(&mut status_report, &pmod);
                         print_usb_state(&mut status_report, &mut i2cdev);
                         print_die_temperature(&mut status_report, &dtr);
-                        psram.ctrl().write(|w| w.collect().bit(false));
-                        let cycles_elapsed: u32 = psram.stats0().read().cycles_elapsed().bits();
-                        let cycles_idle: u32 = psram.stats1().read().cycles_idle().bits();
-                        let cycles_ack_r: u32 = psram.stats2().read().cycles_ack_r().bits();
-                        let cycles_ack_w: u32 = psram.stats3().read().cycles_ack_w().bits();
-                        psram.ctrl().write(|w| w.collect().bit(true));
-                        write!(&mut status_report,
-                               "psram [usage={:.2}, ack_r={:.2}, ack_w={:.2}]",
-                               1.0f32 - (cycles_idle as f32 / cycles_elapsed as f32),
-                               cycles_ack_r as f32 / cycles_elapsed as f32,
-                               cycles_ack_w as f32 / cycles_elapsed as f32);
-                        info!("STATUS REPORT: {}", status_report);
+                        print_psram_stats(&mut status_report, &psram);
                         ("[status report]", &status_report)
                     }
                 };


### PR DESCRIPTION
- Add PSRAM bandwidth monitoring to `selftest` bitstream (total busy %, read % write % and latency overhead %)
- Improve `dma_framebuffer` control logic, now the FIFO only needs to be 1 scanline long as we don't unnecessarily drain it every VSYNC. This reduces DPRAM usage quite a bit.