### PR TITLE
xbeam/raster/dsp: `xbeam` improvements and bonus cleanup

### DIFF
--- a/gateware/src/tiliqua/cache.py
+++ b/gateware/src/tiliqua/cache.py
@@ -289,11 +289,11 @@ class PlotterCache(wiring.Component):
     the persistance emulation) for too long.
     """
 
-    def __init__(self, *, fb_base, addr_width):
+    def __init__(self, *, fb):
 
         # Instantiate a small cache and connect it to the backing store as a DMA master
         self.cache = WishboneL2Cache(
-                addr_width=addr_width,
+                addr_width=fb.bus.addr_width,
                 cachesize_words=64)
 
         # Create an arbiter for different plotting cores to share
@@ -306,7 +306,7 @@ class PlotterCache(wiring.Component):
         # Periodically flush stale cache lines, so we still get a dead beam 'dot'
         # even if the beam is not being deflected despite the write-back cache.
         self.flusher = CacheFlusher(
-            base=fb_base,
+            base=fb.fb_base,
             addr_width=self.cache.master.addr_width,
             burst_len=self.cache.burst_len)
         self.arbiter.add(self.flusher.bus)

--- a/gateware/src/tiliqua/dsp.py
+++ b/gateware/src/tiliqua/dsp.py
@@ -1282,6 +1282,18 @@ def named_submodules(m_submodules, elaboratables, override_name=None):
     else:
         [setattr(m_submodules, f"{override_name}{i}", e) for i, e in enumerate(elaboratables)]
 
+
+def connect_peek(m, stream_peek, stream_dst, always_ready=False):
+    """
+    Nonblocking 'peek', used to tap off an EXISTING stream connection, without
+    influencing it, for inspection / plotting purposes.
+    """
+    m.d.comb += [
+        stream_dst.valid.eq(stream_peek.valid & stream_peek.ready),
+        stream_dst.payload.eq(stream_peek.payload),
+        stream_peek.ready.eq(1) if always_ready else []
+    ]
+
 class Duplicate(wiring.Component):
     """
     Simple 'upsampler' that duplicates each input sample N times.

--- a/gateware/src/tiliqua/dsp.py
+++ b/gateware/src/tiliqua/dsp.py
@@ -1282,3 +1282,50 @@ def named_submodules(m_submodules, elaboratables, override_name=None):
     else:
         [setattr(m_submodules, f"{override_name}{i}", e) for i, e in enumerate(elaboratables)]
 
+class Duplicate(wiring.Component):
+    """
+    Simple 'upsampler' that duplicates each input sample N times.
+
+    No filtering is performed - each input sample is simply repeated N times
+    in the output stream.
+
+    Members
+    -------
+    i : :py:`In(stream.Signature(ASQ))`
+        Input stream for samples to be upsampled.
+    o : :py:`Out(stream.Signature(ASQ))`
+        Output stream producing each input sample N times.
+    """
+
+    i: In(stream.Signature(ASQ))
+    o: Out(stream.Signature(ASQ))
+
+    def __init__(self, n: int):
+        self.n = n
+        super().__init__()
+
+    def elaborate(self, platform):
+        m = Module()
+        if self.n == 1:
+            wiring.connect(m, wiring.flipped(self.i), self.o)
+        else:
+            dup_counter = Signal(range(self.n))
+            current_sample = Signal(ASQ)
+            sample_valid = Signal()
+            m.d.comb += self.i.ready.eq(dup_counter == 0)
+            with m.If(self.i.valid & self.i.ready):
+                m.d.sync += [
+                    current_sample.eq(self.i.payload),
+                    sample_valid.eq(1),
+                    dup_counter.eq(self.n - 1),
+                ]
+            with m.If(self.o.ready & sample_valid):
+                with m.If(dup_counter > 0):
+                    m.d.sync += dup_counter.eq(dup_counter - 1)
+                with m.Else():
+                    m.d.sync += sample_valid.eq(0)
+            m.d.comb += [
+                self.o.valid.eq(sample_valid),
+                self.o.payload.eq(current_sample),
+            ]
+        return m

--- a/gateware/src/tiliqua/eurorack_pmod.py
+++ b/gateware/src/tiliqua/eurorack_pmod.py
@@ -26,6 +26,9 @@ class I2SSignature(wiring.Signature):
     """
     Standard I2S inter-chip audio bus.
     We use TDM for multiple audio channels.
+
+    All signals except MCLK are expected to be going through IO registers,
+    which implies a 1 cycle delay compared to the pin itself.
     """
     def __init__(self):
         super().__init__({
@@ -62,6 +65,8 @@ class FFCProvider(wiring.Component):
         ffc_i2s = platform.request("audio_ffc_i2s", dir={
             "sdin1": "-", "sdout1": "-", "lrck": "-", "bick": "-", "mclk": "-",
         })
+        # Registered IO buffers are necessary for reliable timing at 192kHz (~50MHz MCLK)
+        # so let's just always use them.
         m.submodules.ff_sdout1 = ff_sdout1 = io.FFBuffer(
                 "i", ffc_i2s.sdout1, i_domain="audio")
         m.submodules.ff_sdin1 = ff_sdin1 = io.FFBuffer(
@@ -70,8 +75,11 @@ class FFCProvider(wiring.Component):
                 "o", ffc_i2s.lrck, o_domain="audio")
         m.submodules.ff_bick = ff_bick = io.FFBuffer(
                 "o", ffc_i2s.bick, o_domain="audio")
-        m.submodules.ff_mclk = ff_mclk = io.FFBuffer(
-                "o", ffc_i2s.mclk, o_domain="audio")
+        # MCLK does not need to be an FFBuffer as the MCLK phase does not matter for
+        # most CODECs. from the AK4619VN datasheet, page 32 'the phase of MCLK is
+        # not critical'. This is important as at 48kHz, we drive MCLK combinatorially from
+        # the audio clock domain, which would not work through an FFBuffer.
+        m.submodules.ff_mclk = ff_mclk = io.Buffer("o", ffc_i2s.mclk)
         m.d.comb += [
             # I2S bus
             ff_sdin1.o.eq(self.pins.i2s.sdin1),
@@ -159,6 +167,8 @@ class I2STDM(wiring.Component):
             # BICK transition HI -> LO: Clock in W bits
             # On HI -> LO both SDIN and SDOUT do not transition.
             # (determined by AK4619 transition polarity register BCKP)
+            #
+            # 1-bit offset comes from FFBuffer on sdout1 pin (1 cycle delay)
             with m.If((bit_counter > 0) & (bit_counter <= self.S_WIDTH)):
                 m.d.audio += self.o.eq((self.o << 1) | self.i2s.sdout1)
         with m.Else():

--- a/gateware/src/tiliqua/eurorack_pmod.py
+++ b/gateware/src/tiliqua/eurorack_pmod.py
@@ -101,7 +101,7 @@ class I2STDM(wiring.Component):
     """
 
     N_CHANNELS = 4
-    S_WIDTH    = 24
+    S_WIDTH    = 16
     SLOT_WIDTH = 32
 
     def __init__(self, audio_192=False):

--- a/gateware/src/tiliqua/eurorack_pmod.py
+++ b/gateware/src/tiliqua/eurorack_pmod.py
@@ -101,7 +101,7 @@ class I2STDM(wiring.Component):
     """
 
     N_CHANNELS = 4
-    S_WIDTH    = 16
+    S_WIDTH    = 24
     SLOT_WIDTH = 32
 
     def __init__(self, audio_192=False):

--- a/gateware/src/tiliqua/raster_stroke.py
+++ b/gateware/src/tiliqua/raster_stroke.py
@@ -44,7 +44,7 @@ class Stroke(wiring.Component):
     """
 
 
-    def __init__(self, *, fb: DMAFramebuffer, fs=192000, n_upsample=16,
+    def __init__(self, *, fb: DMAFramebuffer, fs=192000, n_upsample=4,
                  default_hue=10, default_x=0, default_y=0):
 
         self.fb = fb

--- a/gateware/src/tiliqua/raster_stroke.py
+++ b/gateware/src/tiliqua/raster_stroke.py
@@ -97,8 +97,8 @@ class Stroke(wiring.Component):
 
             m.submodules.resample0 = resample0 = dsp.Resample(fs_in=self.fs, n_up=self.n_upsample, m_down=1)
             m.submodules.resample1 = resample1 = dsp.Resample(fs_in=self.fs, n_up=self.n_upsample, m_down=1)
-            m.submodules.resample2 = resample2 = dsp.Resample(fs_in=self.fs, n_up=self.n_upsample, m_down=1)
-            m.submodules.resample3 = resample3 = dsp.Resample(fs_in=self.fs, n_up=self.n_upsample, m_down=1)
+            m.submodules.resample2 = resample2 = dsp.Duplicate(n=self.n_upsample)
+            m.submodules.resample3 = resample3 = dsp.Duplicate(n=self.n_upsample)
 
             wiring.connect(m, plot_fifo.r_stream, split.i)
 

--- a/gateware/src/tiliqua/raster_stroke.py
+++ b/gateware/src/tiliqua/raster_stroke.py
@@ -165,8 +165,8 @@ class Stroke(wiring.Component):
                         sample_x.eq((self.point_stream.payload[0].as_value()>>self.scale_x) + self.x_offset),
                         # invert sample_y for positive scope -> up
                         sample_y.eq((-self.point_stream.payload[1].as_value()>>self.scale_y) + self.y_offset),
-                        sample_p.eq(self.point_stream.payload[2].as_value()>>self.scale_p),
-                        sample_c.eq(self.point_stream.payload[3].as_value()>>self.scale_c),
+                        sample_p.eq(Mux(self.scale_p != 0xf, self.point_stream.payload[2].as_value()>>self.scale_p, 0)),
+                        sample_c.eq(Mux(self.scale_c != 0xf, self.point_stream.payload[3].as_value()>>self.scale_c, 0)),
                     ]
                     m.next = 'LATCH1'
 

--- a/gateware/src/tiliqua/raster_stroke.py
+++ b/gateware/src/tiliqua/raster_stroke.py
@@ -224,9 +224,9 @@ class Stroke(wiring.Component):
 
                 # Calculate sample intensity with bounds checking
                 with m.If((sample_p + self.intensity > 0) & (sample_p + self.intensity <= 0xf)):
-                    m.d.comb += sample_intensity.eq(sample_p + self.intensity)
+                    m.d.sync += sample_intensity.eq(sample_p + self.intensity)
                 with m.Else():
-                    m.d.comb += sample_intensity.eq(0)
+                    m.d.sync += sample_intensity.eq(0)
 
                 # Calculate new intensity (add with saturation)
                 with m.If(current_intensity + sample_intensity >= 0xF):

--- a/gateware/src/tiliqua/scope.py
+++ b/gateware/src/tiliqua/scope.py
@@ -141,7 +141,7 @@ class ScopeTracePeripheral(wiring.Component):
 
     def __init__(self, fb, bus_dma, **kwargs):
 
-        self.strokes = [Stroke(fb=fb, n_upsample=None, **kwargs)
+        self.strokes = [Stroke(fb=fb, **kwargs)
                         for _ in range(4)]
 
         if hasattr(bus_dma, 'add'):

--- a/gateware/src/tiliqua/scope.py
+++ b/gateware/src/tiliqua/scope.py
@@ -35,7 +35,7 @@ class VectorTracePeripheral(wiring.Component):
 
     def __init__(self, fb, bus_dma, **kwargs):
 
-        self.stroke = Stroke(fb=fb, **kwargs)
+        self.stroke = Stroke(fb=fb, n_upsample=8, **kwargs)
         bus_dma.add(self.stroke.bus)
 
         regs = csr.Builder(addr_width=5, data_width=8)
@@ -121,7 +121,7 @@ class ScopeTracePeripheral(wiring.Component):
 
     def __init__(self, fb, bus_dma, **kwargs):
 
-        self.strokes = [Stroke(fb=fb, n_upsample=None, **kwargs)
+        self.strokes = [Stroke(fb=fb, n_upsample=2, **kwargs)
                         for _ in range(4)]
 
         for s in self.strokes:

--- a/gateware/src/tiliqua/scope.py
+++ b/gateware/src/tiliqua/scope.py
@@ -36,7 +36,11 @@ class VectorTracePeripheral(wiring.Component):
     def __init__(self, fb, bus_dma, **kwargs):
 
         self.stroke = Stroke(fb=fb, **kwargs)
-        bus_dma.add(self.stroke.bus)
+
+        if hasattr(bus_dma, 'add'):
+            bus_dma.add(self.stroke.bus)
+        else:
+            bus_dma.add_master(self.stroke.bus)
 
         regs = csr.Builder(addr_width=6, data_width=8)
 
@@ -140,8 +144,12 @@ class ScopeTracePeripheral(wiring.Component):
         self.strokes = [Stroke(fb=fb, n_upsample=None, **kwargs)
                         for _ in range(4)]
 
-        for s in self.strokes:
-            bus_dma.add(s.bus)
+        if hasattr(bus_dma, 'add'):
+            for s in self.strokes:
+                bus_dma.add(s.bus)
+        else:
+            for s in self.strokes:
+                bus_dma.add_master(s.bus)
 
         regs = csr.Builder(addr_width=6, data_width=8)
         self._flags          = regs.add("flags",          self.Flags(),         offset=0x0)

--- a/gateware/src/tiliqua/scope.py
+++ b/gateware/src/tiliqua/scope.py
@@ -35,7 +35,7 @@ class VectorTracePeripheral(wiring.Component):
 
     def __init__(self, fb, bus_dma, **kwargs):
 
-        self.stroke = Stroke(fb=fb, n_upsample=8, **kwargs)
+        self.stroke = Stroke(fb=fb, **kwargs)
         bus_dma.add(self.stroke.bus)
 
         regs = csr.Builder(addr_width=6, data_width=8)

--- a/gateware/src/tiliqua/scope.py
+++ b/gateware/src/tiliqua/scope.py
@@ -168,6 +168,7 @@ class ScopeTracePeripheral(wiring.Component):
             "en": In(1),
             "soc_en": In(1),
             "rotate_left": In(1),
+            # CSR bus
             "bus": In(csr.Signature(addr_width=regs.addr_width, data_width=regs.data_width)),
         })
         self.bus.memory_map = self._bridge.bus.memory_map

--- a/gateware/src/tiliqua/tiliqua_platform.py
+++ b/gateware/src/tiliqua/tiliqua_platform.py
@@ -367,7 +367,7 @@ class _TiliquaR4Mobo:
             Subsignal("pdn_clk", Pins("56", dir="o",  conn=("m2", 0))),
             Subsignal("i2c_sda", Pins("71", dir="io", conn=("m2", 0))),
             Subsignal("i2c_scl", Pins("69", dir="io", conn=("m2", 0))),
-            Attrs(IO_TYPE="LVCMOS33", DRIVE="4", SLEWRATE="SLOW")
+            Attrs(IO_TYPE="LVCMOS33", DRIVE="8", SLEWRATE="FAST")
         ),
 
         # DVI

--- a/gateware/src/tiliqua/tiliqua_platform.py
+++ b/gateware/src/tiliqua/tiliqua_platform.py
@@ -357,12 +357,16 @@ class _TiliquaR4Mobo:
         ),
 
         # FFC connector to eurorack-pmod on the back.
-        Resource("audio_ffc", 0,
+        Resource("audio_ffc_i2s", 0,
             Subsignal("sdin1",   Pins("42", dir="o",  conn=("m2", 0))),
             Subsignal("sdout1",  Pins("46", dir="i",  conn=("m2", 0))),
             Subsignal("lrck",    Pins("48", dir="o",  conn=("m2", 0))),
             Subsignal("bick",    Pins("50", dir="o",  conn=("m2", 0))),
             Subsignal("mclk",    Pins("67", dir="o",  conn=("m2", 0))),
+            Attrs(IO_TYPE="LVCMOS33", DRIVE="8", SLEWRATE="FAST")
+        ),
+
+        Resource("audio_ffc_aux", 0,
             Subsignal("pdn_d",   Pins("65", dir="o",  conn=("m2", 0))),
             Subsignal("pdn_clk", Pins("56", dir="o",  conn=("m2", 0))),
             Subsignal("i2c_sda", Pins("71", dir="io", conn=("m2", 0))),

--- a/gateware/src/tiliqua/tiliqua_platform.py
+++ b/gateware/src/tiliqua/tiliqua_platform.py
@@ -380,16 +380,11 @@ class _TiliquaR4Mobo:
             Subsignal("ck", Pins("52", dir="o", conn=("m2", 0))),
             Attrs(IO_TYPE="LVCMOS33D", DRIVE="8", SLEWRATE="FAST")
          ),
-
-        Resource("debug", 0,
-            Subsignal("debug0",  Pins("41", dir="o",  conn=("m2", 0))),
-            Subsignal("debug1",  Pins("73", dir="o",  conn=("m2", 0))),
-         )
     ]
 
     # Expansion connectors ex0 and ex1
     connectors  = [
-        #Connector("pmod", 0, "55 38 66 41 - - 57 35 34 70 - -", conn=("m2", 0)),
+        Connector("pmod", 0, "55 38 66 41 - - 57 35 34 70 - -", conn=("m2", 0)),
         Connector("pmod", 1, "59 63 14 20 - - 61 15 13 22 - -", conn=("m2", 0)),
     ]
 

--- a/gateware/src/tiliqua/tiliqua_platform.py
+++ b/gateware/src/tiliqua/tiliqua_platform.py
@@ -182,13 +182,16 @@ class _TiliquaR2Mobo:
             attrs=Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")
         ),
 
-        # FFC connector to eurorack-pmod on the back.
-        Resource("audio_ffc", 0,
+        Resource("audio_ffc_i2s", 0,
             Subsignal("sdin1",   Pins("44", dir="o",  conn=("m2", 0))),
             Subsignal("sdout1",  Pins("46", dir="i",  conn=("m2", 0))),
             Subsignal("lrck",    Pins("48", dir="o",  conn=("m2", 0))),
             Subsignal("bick",    Pins("50", dir="o",  conn=("m2", 0))),
             Subsignal("mclk",    Pins("52", dir="o",  conn=("m2", 0))),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        Resource("audio_ffc_aux", 0,
             Subsignal("pdn_d",   Pins("54", dir="o",  conn=("m2", 0))),
             Subsignal("i2c_sda", Pins("56", dir="io", conn=("m2", 0))),
             Subsignal("i2c_scl", Pins("58", dir="io", conn=("m2", 0))),
@@ -256,13 +259,16 @@ class _TiliquaR3Mobo:
             attrs=Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")
         ),
 
-        # FFC connector to eurorack-pmod on the back.
-        Resource("audio_ffc", 0,
+        Resource("audio_ffc_i2s", 0,
             Subsignal("sdin1",   Pins("44", dir="o",  conn=("m2", 0))),
             Subsignal("sdout1",  Pins("46", dir="i",  conn=("m2", 0))),
             Subsignal("lrck",    Pins("48", dir="o",  conn=("m2", 0))),
             Subsignal("bick",    Pins("50", dir="o",  conn=("m2", 0))),
             Subsignal("mclk",    Pins("67", dir="o",  conn=("m2", 0))),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
+
+        Resource("audio_ffc_aux", 0,
             Subsignal("pdn_d",   Pins("65", dir="o",  conn=("m2", 0))),
             Subsignal("pdn_clk", Pins("56", dir="o",  conn=("m2", 0))),
             Subsignal("i2c_sda", Pins("71", dir="io", conn=("m2", 0))),

--- a/gateware/src/tiliqua/tiliqua_platform.py
+++ b/gateware/src/tiliqua/tiliqua_platform.py
@@ -356,22 +356,23 @@ class _TiliquaR4Mobo:
             attrs=Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")
         ),
 
-        # FFC connector to eurorack-pmod on the back.
+        # Audio FFC: I2S interface to CODEC
         Resource("audio_ffc_i2s", 0,
             Subsignal("sdin1",   Pins("42", dir="o",  conn=("m2", 0))),
             Subsignal("sdout1",  Pins("46", dir="i",  conn=("m2", 0))),
             Subsignal("lrck",    Pins("48", dir="o",  conn=("m2", 0))),
             Subsignal("bick",    Pins("50", dir="o",  conn=("m2", 0))),
             Subsignal("mclk",    Pins("67", dir="o",  conn=("m2", 0))),
-            Attrs(IO_TYPE="LVCMOS33", DRIVE="8", SLEWRATE="FAST")
+            Attrs(IO_TYPE="LVCMOS33", DRIVE="4", SLEWRATE="SLOW")
         ),
 
+        # Audio FFC: Other pins (mute/power, control I2C)
         Resource("audio_ffc_aux", 0,
             Subsignal("pdn_d",   Pins("65", dir="o",  conn=("m2", 0))),
             Subsignal("pdn_clk", Pins("56", dir="o",  conn=("m2", 0))),
             Subsignal("i2c_sda", Pins("71", dir="io", conn=("m2", 0))),
             Subsignal("i2c_scl", Pins("69", dir="io", conn=("m2", 0))),
-            Attrs(IO_TYPE="LVCMOS33", DRIVE="8", SLEWRATE="FAST")
+            Attrs(IO_TYPE="LVCMOS33", DRIVE="4", SLEWRATE="SLOW")
         ),
 
         # DVI

--- a/gateware/src/tiliqua/tiliqua_platform.py
+++ b/gateware/src/tiliqua/tiliqua_platform.py
@@ -380,11 +380,16 @@ class _TiliquaR4Mobo:
             Subsignal("ck", Pins("52", dir="o", conn=("m2", 0))),
             Attrs(IO_TYPE="LVCMOS33D", DRIVE="8", SLEWRATE="FAST")
          ),
+
+        Resource("debug", 0,
+            Subsignal("debug0",  Pins("41", dir="o",  conn=("m2", 0))),
+            Subsignal("debug1",  Pins("73", dir="o",  conn=("m2", 0))),
+         )
     ]
 
     # Expansion connectors ex0 and ex1
     connectors  = [
-        Connector("pmod", 0, "55 38 66 41 - - 57 35 34 70 - -", conn=("m2", 0)),
+        #Connector("pmod", 0, "55 38 66 41 - - 57 35 34 70 - -", conn=("m2", 0)),
         Connector("pmod", 1, "59 63 14 20 - - 61 15 13 22 - -", conn=("m2", 0)),
     ]
 

--- a/gateware/src/tiliqua/usb_audio/__init__.py
+++ b/gateware/src/tiliqua/usb_audio/__init__.py
@@ -42,21 +42,21 @@ from .usb_stream_to_channels                  import USBStreamToChannels
 from .channels_to_usb_stream                  import ChannelsToUSBStream
 from .audio_to_channels                       import AudioToChannels
 
-from tiliqua                                  import eurorack_pmod
+from tiliqua                                  import eurorack_pmod, types
 
 
 class USB2AudioInterface(wiring.Component):
+
     """ USB Audio Class v2 interface """
 
-    NR_CHANNELS = 4
-    MAX_PACKET_SIZE = int(4 * 224 // 8 * NR_CHANNELS)
-    MAX_PACKET_SIZE_MIDI = 64
-
-    i:    In(stream.Signature(data.ArrayLayout(eurorack_pmod.ASQ, 4)))
-    o:   Out(stream.Signature(data.ArrayLayout(eurorack_pmod.ASQ, 4)))
-
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *, audio_clock: types.AudioClock, nr_channels):
+        self.fs = 192000 if audio_clock.is_192khz() else 48000
+        self.nr_channels = nr_channels
+        self.max_packet_size = int(32 * (self.fs // 48000) * self.nr_channels)
+        super().__init__({
+            "i":  In(stream.Signature(data.ArrayLayout(eurorack_pmod.ASQ, self.nr_channels))),
+            "o": Out(stream.Signature(data.ArrayLayout(eurorack_pmod.ASQ, self.nr_channels)))
+        })
 
     def create_descriptors(self):
         """ Creates the descriptors that describe our audio topology. """
@@ -119,7 +119,7 @@ class USB2AudioInterface(wiring.Component):
         # default audio out device by Windows. We provide an alternate
         # setting with the full channel count, which also references
         # this terminal ID
-        inputTerminal.bNrChannels   = self.NR_CHANNELS
+        inputTerminal.bNrChannels   = self.nr_channels
         inputTerminal.bCSourceID    = 1
         audioControlInterface.add_subordinate_descriptor(inputTerminal)
 
@@ -135,7 +135,7 @@ class USB2AudioInterface(wiring.Component):
         inputTerminal               = uac2.InputTerminalDescriptorEmitter()
         inputTerminal.bTerminalID   = 4
         inputTerminal.wTerminalType = uac2.InputTerminalTypes.MICROPHONE
-        inputTerminal.bNrChannels   = self.NR_CHANNELS
+        inputTerminal.bNrChannels   = self.nr_channels
         inputTerminal.bCSourceID    = 1
         audioControlInterface.add_subordinate_descriptor(inputTerminal)
 
@@ -178,7 +178,7 @@ class USB2AudioInterface(wiring.Component):
         audioOutEndpoint.bmAttributes         = USBTransferType.ISOCHRONOUS  | \
                                                 (USBSynchronizationType.ASYNC << 2) | \
                                                 (USBUsageType.DATA << 4)
-        audioOutEndpoint.wMaxPacketSize = self.MAX_PACKET_SIZE
+        audioOutEndpoint.wMaxPacketSize = self.max_packet_size
         audioOutEndpoint.bInterval       = 1
         c.add_subordinate_descriptor(audioOutEndpoint)
 
@@ -209,7 +209,7 @@ class USB2AudioInterface(wiring.Component):
         # we need the default alternate setting to be stereo
         # out for windows to automatically recognize
         # and use this audio interface
-        self.create_output_streaming_interface(c, nr_channels=self.NR_CHANNELS, alt_setting_nr=1)
+        self.create_output_streaming_interface(c, nr_channels=self.nr_channels, alt_setting_nr=1)
 
 
     def create_input_streaming_interface(self, c, *, nr_channels, alt_setting_nr, channel_config=0):
@@ -241,7 +241,7 @@ class USB2AudioInterface(wiring.Component):
         audioOutEndpoint.bmAttributes         = USBTransferType.ISOCHRONOUS  | \
                                                 (USBSynchronizationType.ASYNC << 2) | \
                                                 (USBUsageType.DATA << 4)
-        audioOutEndpoint.wMaxPacketSize = self.MAX_PACKET_SIZE
+        audioOutEndpoint.wMaxPacketSize = self.max_packet_size
         audioOutEndpoint.bInterval      = 1
         c.add_subordinate_descriptor(audioOutEndpoint)
 
@@ -260,7 +260,7 @@ class USB2AudioInterface(wiring.Component):
         c.add_subordinate_descriptor(quietAudioStreamingInterface)
 
         # Windows wants a stereo pair as default setting, so let's have it
-        self.create_input_streaming_interface(c, nr_channels=self.NR_CHANNELS, alt_setting_nr=1, channel_config=0x3)
+        self.create_input_streaming_interface(c, nr_channels=self.nr_channels, alt_setting_nr=1, channel_config=0x3)
 
     def elaborate(self, platform):
         m = Module()
@@ -277,7 +277,7 @@ class USB2AudioInterface(wiring.Component):
         ])
 
         # Attach our class request handlers.
-        class_request_handler = UAC2RequestHandlers()
+        class_request_handler = UAC2RequestHandlers(fs=self.fs)
         control_ep.add_request_handler(class_request_handler)
 
         # Attach class-request handlers that stall any vendor or reserved requests,
@@ -289,7 +289,7 @@ class USB2AudioInterface(wiring.Component):
 
         ep1_out = USBIsochronousStreamOutEndpoint(
             endpoint_number=1, # EP 1 OUT
-            max_packet_size=self.MAX_PACKET_SIZE)
+            max_packet_size=self.max_packet_size)
         usb.add_endpoint(ep1_out)
 
         ep1_in = USBIsochronousInEndpoint(
@@ -299,11 +299,11 @@ class USB2AudioInterface(wiring.Component):
 
         ep2_in = USBIsochronousStreamInEndpoint(
             endpoint_number=2, # EP 2 IN
-            max_packet_size=self.MAX_PACKET_SIZE)
+            max_packet_size=self.max_packet_size)
         usb.add_endpoint(ep2_in)
 
         # calculate bytes in frame for audio in
-        audio_in_frame_bytes = Signal(range(self.MAX_PACKET_SIZE), reset=24 * self.NR_CHANNELS)
+        audio_in_frame_bytes = Signal(range(self.max_packet_size), reset=24 * self.nr_channels)
         audio_in_frame_bytes_counting = Signal()
 
         with m.If(ep1_out.stream.valid & ep1_out.stream.ready):
@@ -337,11 +337,7 @@ class USB2AudioInterface(wiring.Component):
         # need 16 bits here
         audio_clock_counter = Signal(24)
         sof_counter         = Signal(8)
-
         audio_clock_usb = Signal()
-        audio_clkdiv = Signal(2)
-        m.d.audio += audio_clkdiv.eq(audio_clkdiv+1)
-        m.submodules.audio_clock_usb_sync = FFSynchronizer(audio_clkdiv[-1], audio_clock_usb, o_domain="usb")
         m.submodules.audio_clock_usb_pulse = audio_clock_usb_pulse = DomainRenamer("usb")(EdgeToPulse())
         audio_clock_tick = Signal()
         m.d.usb += [
@@ -349,9 +345,21 @@ class USB2AudioInterface(wiring.Component):
             audio_clock_tick.eq(audio_clock_usb_pulse.pulse_out),
         ]
 
-        with m.If(audio_clock_tick):
-            m.d.usb += audio_clock_counter.eq(audio_clock_counter + 4)
-
+        match self.fs:
+            case 192000:
+                # Audio clock dangerously close to USB clock, divide it down before synchronizing into USB domain
+                audio_clkdiv = Signal(2)
+                m.d.audio += audio_clkdiv.eq(audio_clkdiv+1)
+                m.submodules.audio_clock_usb_sync = FFSynchronizer(audio_clkdiv[-1], audio_clock_usb, o_domain="usb")
+                with m.If(audio_clock_tick):
+                    m.d.usb += audio_clock_counter.eq(audio_clock_counter + 4)
+            case 48000:
+                # Audio clock not close to USB clock, no need for divider.
+                m.submodules.audio_clock_usb_sync = FFSynchronizer(ClockSignal("audio"), audio_clock_usb, o_domain="usb")
+                with m.If(audio_clock_tick):
+                    m.d.usb += audio_clock_counter.eq(audio_clock_counter + 1)
+            case _:
+                raise ValueError("audio clock tracking only tested for 48khz/192khz")
 
         m.d.comb += [
             bitPos.eq(ep1_in.address << 3),
@@ -359,10 +367,10 @@ class USB2AudioInterface(wiring.Component):
         ]
 
         m.submodules.usb_to_channel_stream = usb_to_channel_stream = \
-            DomainRenamer("usb")(USBStreamToChannels(self.NR_CHANNELS))
+            DomainRenamer("usb")(USBStreamToChannels(self.nr_channels))
 
         m.submodules.channels_to_usb_stream = channels_to_usb_stream = \
-            DomainRenamer("usb")(ChannelsToUSBStream(self.NR_CHANNELS, max_packet_size=self.MAX_PACKET_SIZE))
+            DomainRenamer("usb")(ChannelsToUSBStream(self.nr_channels, max_packet_size=self.max_packet_size))
 
         def detect_active_audio_in(m, name: str, usb, ep2_in):
             audio_in_seen   = Signal(name=f"{name}_audio_in_seen")
@@ -388,14 +396,15 @@ class USB2AudioInterface(wiring.Component):
         wiring.connect(m,  wiring.flipped(ep2_in.stream), channels_to_usb_stream.usb_stream_out)
 
         m.d.comb += [
-            channels_to_usb_stream.no_channels_in.eq(self.NR_CHANNELS),
+            channels_to_usb_stream.no_channels_in.eq(self.nr_channels),
             channels_to_usb_stream.data_requested_in.eq(ep2_in.data_requested),
             channels_to_usb_stream.frame_finished_in.eq(ep2_in.frame_finished),
             channels_to_usb_stream.audio_in_active.eq(usb_audio_in_active),
-            usb_to_channel_stream.no_channels_in.eq(self.NR_CHANNELS),
+            usb_to_channel_stream.no_channels_in.eq(self.nr_channels),
         ]
 
         m.submodules.audio_to_channels = audio_to_channels = AudioToChannels(
+                nr_channels=self.nr_channels,
                 to_usb_stream=channels_to_usb_stream.channel_stream_in,
                 from_usb_stream=usb_to_channel_stream.channel_stream_out)
         wiring.connect(m, wiring.flipped(self.i), audio_to_channels.i)
@@ -424,9 +433,10 @@ class USB2AudioInterface(wiring.Component):
 
 class UAC2RequestHandlers(USBRequestHandler):
     """ request handlers to implement UAC2 functionality. """
-    def __init__(self):
+    def __init__(self, fs):
         super().__init__()
 
+        self.fs = fs
         self.output_interface_altsetting_nr = Signal(3)
         self.input_interface_altsetting_nr  = Signal(3)
         self.interface_settings_changed     = Signal()
@@ -485,8 +495,8 @@ class UAC2RequestHandlers(USBRequestHandler):
                         m.d.comb += [
                             Cat(transmitter.data).eq(
                                 Cat(Const(0x1, 16), # no triples
-                                    Const(192000, 32), # MIN
-                                    Const(192000, 32), # MAX
+                                    Const(self.fs, 32), # MIN
+                                    Const(self.fs, 32), # MAX
                                     Const(0, 32))),   # RES
                             transmitter.max_length.eq(setup.length)
                         ]
@@ -506,7 +516,7 @@ class UAC2RequestHandlers(USBRequestHandler):
                     m.d.comb += transmitter.stream.attach(self.interface.tx)
                     with m.If(request_clock_freq & (setup.length == 4)):
                         m.d.comb += [
-                            Cat(transmitter.data[0:4]).eq(Const(192000, 32)),
+                            Cat(transmitter.data[0:4]).eq(Const(self.fs, 32)),
                             transmitter.max_length.eq(4)
                         ]
                     with m.Else():

--- a/gateware/src/tiliqua/usb_audio/__init__.py
+++ b/gateware/src/tiliqua/usb_audio/__init__.py
@@ -260,7 +260,7 @@ class USB2AudioInterface(wiring.Component):
         c.add_subordinate_descriptor(quietAudioStreamingInterface)
 
         # Windows wants a stereo pair as default setting, so let's have it
-        self.create_input_streaming_interface(c, nr_channels=self.NR_CHANNELS, alt_setting_nr=1, channel_config=0x3)
+        #self.create_input_streaming_interface(c, nr_channels=self.NR_CHANNELS, alt_setting_nr=1, channel_config=0x3)
 
     def elaborate(self, platform):
         m = Module()

--- a/gateware/src/tiliqua/usb_audio/__init__.py
+++ b/gateware/src/tiliqua/usb_audio/__init__.py
@@ -53,6 +53,12 @@ class USB2AudioInterface(wiring.Component):
                 "sof_detected": Out(1),
                 "dac_fifo_level": Out(8),
                 "adc_fifo_level": Out(8),
+                "garbage_seen_out": Out(1),
+                "channel_stream_out_valid": Out(1),
+                "channel_stream_out_first": Out(1),
+                "usb_stream_in_valid": Out(1),
+                "usb_stream_in_ready": Out(1),
+                "usb_stream_in_payload": Out(8),
             })
 
     """ USB Audio Class v2 interface """
@@ -444,6 +450,11 @@ class USB2AudioInterface(wiring.Component):
             self.dbg.dac_fifo_level.eq(audio_to_channels.dac_fifo_level),
             self.dbg.adc_fifo_level.eq(audio_to_channels.adc_fifo_level),
             self.dbg.sof_detected.eq(usb.sof_detected),
+            self.dbg.channel_stream_out_valid.eq(usb_to_channel_stream.channel_stream_out.valid),
+            self.dbg.channel_stream_out_first.eq(usb_to_channel_stream.channel_stream_out.first),
+            self.dbg.usb_stream_in_valid.eq(usb_to_channel_stream.usb_stream_in.valid),
+            self.dbg.usb_stream_in_payload.eq(usb_to_channel_stream.usb_stream_in.payload),
+            self.dbg.usb_stream_in_ready.eq(usb_to_channel_stream.usb_stream_in.ready),
         ]
 
         return m

--- a/gateware/src/tiliqua/usb_audio/__init__.py
+++ b/gateware/src/tiliqua/usb_audio/__init__.py
@@ -350,7 +350,7 @@ class USB2AudioInterface(wiring.Component):
         ]
 
         with m.If(audio_clock_tick):
-            m.d.usb += audio_clock_counter.eq(audio_clock_counter + 2)
+            m.d.usb += audio_clock_counter.eq(audio_clock_counter + 4)
 
 
         m.d.comb += [

--- a/gateware/src/tiliqua/usb_audio/__init__.py
+++ b/gateware/src/tiliqua/usb_audio/__init__.py
@@ -260,7 +260,7 @@ class USB2AudioInterface(wiring.Component):
         c.add_subordinate_descriptor(quietAudioStreamingInterface)
 
         # Windows wants a stereo pair as default setting, so let's have it
-        #self.create_input_streaming_interface(c, nr_channels=self.NR_CHANNELS, alt_setting_nr=1, channel_config=0x3)
+        self.create_input_streaming_interface(c, nr_channels=self.NR_CHANNELS, alt_setting_nr=1, channel_config=0x3)
 
     def elaborate(self, platform):
         m = Module()
@@ -362,7 +362,7 @@ class USB2AudioInterface(wiring.Component):
             DomainRenamer("usb")(USBStreamToChannels(self.NR_CHANNELS))
 
         m.submodules.channels_to_usb_stream = channels_to_usb_stream = \
-            DomainRenamer("usb")(ChannelsToUSBStream(self.NR_CHANNELS))
+            DomainRenamer("usb")(ChannelsToUSBStream(self.NR_CHANNELS, max_packet_size=self.MAX_PACKET_SIZE))
 
         def detect_active_audio_in(m, name: str, usb, ep2_in):
             audio_in_seen   = Signal(name=f"{name}_audio_in_seen")

--- a/gateware/src/tiliqua/usb_audio/audio_to_channels.py
+++ b/gateware/src/tiliqua/usb_audio/audio_to_channels.py
@@ -111,13 +111,10 @@ class AudioToChannels(wiring.Component):
                 if n == 0:
                     m.d.usb += dac_fifo.w_en.eq(1)
 
-        dbg = platform.request('debug')
         m.d.comb += [
             self.dac_fifo_level.eq(dac_fifo.w_level),
             self.adc_fifo_level.eq(adc_fifo.r_level),
             self.from_usb.ready.eq(dac_fifo.w_rdy),
-            dbg.debug0.o.eq(dac_fifo.w_rdy),
-            dbg.debug1.o.eq(dac_fifo.r_rdy),
         ]
 
         return m

--- a/gateware/src/tiliqua/usb_audio/audio_to_channels.py
+++ b/gateware/src/tiliqua/usb_audio/audio_to_channels.py
@@ -110,9 +110,12 @@ class AudioToChannels(wiring.Component):
                 if n == 0:
                     m.d.usb += dac_fifo.w_en.eq(1)
 
+        dbg = platform.request('debug')
         m.d.comb += [
-            self.dac_fifo_level.eq(m.submodules.dac_fifo.r_level),
+            self.dac_fifo_level.eq(m.submodules.dac_fifo.w_level),
             self.from_usb.ready.eq(dac_fifo.w_rdy),
+            dbg.debug0.o.eq(dac_fifo.w_rdy),
+            dbg.debug1.o.eq(dac_fifo.r_rdy),
         ]
 
         return m

--- a/gateware/src/tiliqua/usb_audio/audio_to_channels.py
+++ b/gateware/src/tiliqua/usb_audio/audio_to_channels.py
@@ -99,8 +99,8 @@ class AudioToChannels(wiring.Component):
         # OUTPUT SIDE
         # HOST -> USB Channel stream -> eurorack-pmod calibrated OUTPUT samples.
         #
-
         m.submodules.dac_fifo = dac_fifo = AsyncFIFOBuffered(width=SW*self.nr_channels, depth=self.fifo_depth, w_domain="usb", r_domain="sync")
+        wiring.connect(m, dac_fifo.r_stream, wiring.flipped(self.o));
 
         m.d.usb += dac_fifo.w_en.eq(0)
         for n in range(self.nr_channels):

--- a/gateware/src/tiliqua/usb_audio/audio_to_channels.py
+++ b/gateware/src/tiliqua/usb_audio/audio_to_channels.py
@@ -15,17 +15,18 @@ class AudioToChannels(wiring.Component):
     to `channels_to_usb_stream` and `usb_stream_to_channels` logic in the USB domain.
     """
 
-    # streams for hooking up to audio source / sink, sent / recieved over USB.
-    i:    In(stream.Signature(data.ArrayLayout(ASQ, 4)))
-    o:   Out(stream.Signature(data.ArrayLayout(ASQ, 4)))
-
     # TODO: legacy: internal USB streams should be exposed as an ordinary wiring.Component.
 
-    def __init__(self, to_usb_stream, from_usb_stream):
+    def __init__(self, nr_channels, to_usb_stream, from_usb_stream):
+        self.nr_channels = nr_channels
         self.to_usb = to_usb_stream
         self.from_usb = from_usb_stream
         self.dac_fifo_level = Signal(16)
-        super().__init__()
+        super().__init__({
+            # streams for hooking up to audio source / sink, sent / recieved over USB.
+            "i":  In(stream.Signature(data.ArrayLayout(ASQ, self.nr_channels))),
+            "o": Out(stream.Signature(data.ArrayLayout(ASQ, self.nr_channels)))
+        })
 
     def elaborate(self, platform) -> Module:
 
@@ -43,7 +44,7 @@ class AudioToChannels(wiring.Component):
         # eurorack-pmod calibrated INPUT samples -> USB Channel stream -> HOST
         #
 
-        m.submodules.adc_fifo = adc_fifo = AsyncFIFO(width=SW*4, depth=16, w_domain="sync", r_domain="usb")
+        m.submodules.adc_fifo = adc_fifo = AsyncFIFO(width=SW*self.nr_channels, depth=16, w_domain="sync", r_domain="usb")
 
         # (sync domain) on every sample strobe, latch and write all channels concatenated into one entry
         # of adc_fifo.
@@ -55,7 +56,7 @@ class AudioToChannels(wiring.Component):
         # per sample strobe in the audio domain.
 
         # Storage for samples in the USB domain as we send them to the channel stream.
-        adc_latched = Signal(SW*4)
+        adc_latched = Signal(SW*self.nr_channels)
 
         with m.FSM(domain="usb") as fsm:
 
@@ -88,21 +89,20 @@ class AudioToChannels(wiring.Component):
                         m.d.usb += self.to_usb.valid.eq(0)
                         m.next = next_state_name
 
-            generate_channel_states(0, 'CH1')
-            generate_channel_states(1, 'CH2')
-            generate_channel_states(2, 'CH3')
-            generate_channel_states(3, 'WAIT')
+            for n in range(self.nr_channels-1):
+                generate_channel_states(n, f'CH{n+1}')
+            generate_channel_states(self.nr_channels-1, 'WAIT')
 
         #
         # OUTPUT SIDE
         # HOST -> USB Channel stream -> eurorack-pmod calibrated OUTPUT samples.
         #
 
-        m.submodules.dac_fifo = dac_fifo = AsyncFIFO(width=SW*4, depth=16, w_domain="usb", r_domain="sync")
+        m.submodules.dac_fifo = dac_fifo = AsyncFIFO(width=SW*self.nr_channels, depth=16, w_domain="usb", r_domain="sync")
         wiring.connect(m, dac_fifo.r_stream, wiring.flipped(self.o));
 
         m.d.usb += dac_fifo.w_en.eq(0)
-        for n in range(4):
+        for n in range(self.nr_channels):
             with m.If((self.from_usb.channel_nr == n) & self.from_usb.valid):
                 m.d.usb += dac_fifo.w_data[n*SW:(n+1)*SW].eq(self.from_usb.payload[N_ZFILL:])
                 # Write all channels on every incoming zero'th channel

--- a/gateware/src/tiliqua/usb_audio/audio_to_channels.py
+++ b/gateware/src/tiliqua/usb_audio/audio_to_channels.py
@@ -60,26 +60,13 @@ class AudioToChannels(wiring.Component):
         # Storage for samples in the USB domain as we send them to the channel stream.
         adc_latched = Signal(SW*self.nr_channels)
 
-        # ADC underrun/overrun handling
-        adc_underrun = Signal()
-        adc_overrun = Signal()
-        with m.If(adc_fifo.r_level == 0):
-            m.d.usb += adc_underrun.eq(1)
-        with m.If(adc_fifo.r_level == self.fifo_depth+1):
-            m.d.usb += adc_overrun.eq(1)
-        with m.If(adc_underrun | adc_overrun):
-            with m.If(adc_fifo.r_level == (self.fifo_depth//2)):
-                m.d.usb += adc_underrun.eq(0)
-                m.d.usb += adc_overrun.eq(0)
-
         with m.FSM(domain="usb") as fsm:
 
             with m.State('WAIT'):
                 m.d.usb += self.to_usb.valid.eq(0),
                 with m.If(adc_fifo.r_rdy):
-                    m.d.usb += adc_fifo.r_en.eq(~adc_underrun)
-                    with m.If(~adc_overrun):
-                        m.next = 'LATCH'
+                    m.d.usb += adc_fifo.r_en.eq(1)
+                    m.next = 'LATCH'
 
             with m.State('LATCH'):
                 m.d.usb += [
@@ -115,7 +102,6 @@ class AudioToChannels(wiring.Component):
 
         m.submodules.dac_fifo = dac_fifo = AsyncFIFOBuffered(width=SW*self.nr_channels, depth=self.fifo_depth, w_domain="usb", r_domain="sync")
 
-        dac_overrun = Signal()
         m.d.usb += dac_fifo.w_en.eq(0)
         for n in range(self.nr_channels):
             with m.If((self.from_usb.channel_nr == n) & self.from_usb.valid):
@@ -123,20 +109,7 @@ class AudioToChannels(wiring.Component):
                 # Write all channels on every incoming zero'th channel
                 # This should work even if < 4 channels are used.
                 if n == 0:
-                    m.d.usb += dac_fifo.w_en.eq(~dac_overrun)
-
-        # DAC underrun/overrun handling
-        dac_underrun = Signal()
-        with m.If(dac_fifo.w_level == 0):
-            m.d.usb += dac_underrun.eq(1)
-        with m.If(dac_fifo.w_level == self.fifo_depth+1):
-            m.d.usb += dac_overrun.eq(1)
-        with m.If(~dac_underrun):
-            wiring.connect(m, dac_fifo.r_stream, wiring.flipped(self.o));
-        with m.If(dac_underrun | dac_overrun):
-            with m.If(dac_fifo.w_level == (self.fifo_depth//2)):
-                m.d.usb += dac_underrun.eq(0)
-                m.d.usb += dac_overrun.eq(0)
+                    m.d.usb += dac_fifo.w_en.eq(1)
 
         dbg = platform.request('debug')
         m.d.comb += [

--- a/gateware/src/top/macro_osc/fw/src/main.rs
+++ b/gateware/src/top/macro_osc/fw/src/main.rs
@@ -294,8 +294,8 @@ fn main() -> ! {
             unsafe {
                 vscope.hue().write(|w| w.hue().bits(opts.beam.hue.value+4));
                 vscope.intensity().write(|w| w.intensity().bits(opts.beam.intensity.value));
-                vscope.xscale().write(|w| w.xscale().bits(opts.vector.xscale.value));
-                vscope.yscale().write(|w| w.yscale().bits(opts.vector.yscale.value));
+                vscope.xscale().write(|w| w.scale().bits(opts.vector.xscale.value));
+                vscope.yscale().write(|w| w.scale().bits(opts.vector.yscale.value));
 
                 scope.hue().write(|w| w.hue().bits(opts.beam.hue.value+6));
                 scope.intensity().write(|w| w.intensity().bits(opts.beam.intensity.value));

--- a/gateware/src/top/macro_osc/fw/src/main.rs
+++ b/gateware/src/top/macro_osc/fw/src/main.rs
@@ -292,7 +292,7 @@ fn main() -> ! {
             persist.set_decay(opts.beam.decay.value);
 
             unsafe {
-                vscope.hue().write(|w| w.hue().bits(opts.beam.hue.value+4));
+                vscope.hue().write(|w| w.hue().bits(opts.beam.hue.value));
                 vscope.intensity().write(|w| w.intensity().bits(opts.beam.intensity.value));
                 vscope.xscale().write(|w| w.scale().bits(opts.vector.xscale.value));
                 vscope.yscale().write(|w| w.scale().bits(opts.vector.yscale.value));

--- a/gateware/src/top/macro_osc/fw/src/options.rs
+++ b/gateware/src/top/macro_osc/fw/src/options.rs
@@ -89,7 +89,7 @@ pub struct BeamOpts {
     pub persist: IntOption<PersistParams>,
     #[option(1)]
     pub decay: IntOption<DecayParams>,
-    #[option(15)]
+    #[option(8)]
     pub intensity: IntOption<IntensityParams>,
     #[option(10)]
     pub hue: IntOption<HueParams>,

--- a/gateware/src/top/macro_osc/top.py
+++ b/gateware/src/top/macro_osc/top.py
@@ -173,7 +173,9 @@ class MacroOscSoc(TiliquaSoc):
 
         self.vector_periph = scope.VectorTracePeripheral(
             fb=self.fb,
-            bus_dma=self.psram_periph)
+            bus_dma=self.psram_periph,
+            n_upsample=8,
+            fs=48000)
         self.csr_decoder.add(self.vector_periph.bus, addr=self.vector_periph_base, name="vector_periph")
 
         self.scope_periph = scope.ScopeTracePeripheral(

--- a/gateware/src/top/macro_osc/top.py
+++ b/gateware/src/top/macro_osc/top.py
@@ -71,7 +71,7 @@ class AudioFIFOPeripheral(wiring.Component):
     class FifoLenReg(csr.Register, access="r"):
         fifo_len: csr.Field(csr.action.R, unsigned(16))
 
-    def __init__(self, fifo_sz=4*4, fifo_data_width=32, granularity=8, elastic_sz=128*3):
+    def __init__(self, fifo_sz=4*4, fifo_data_width=32, granularity=8, elastic_sz=128*4):
         regs = csr.Builder(addr_width=6, data_width=8)
 
         # Out and Aux FIFOs

--- a/gateware/src/top/polysyn/fw/src/main.rs
+++ b/gateware/src/top/polysyn/fw/src/main.rs
@@ -274,8 +274,8 @@ fn main() -> ! {
 
             vscope.hue().write(|w| unsafe { w.hue().bits(opts.beam.hue.value) } );
             vscope.intensity().write(|w| unsafe { w.intensity().bits(opts.beam.intensity.value) } );
-            vscope.xscale().write(|w| unsafe { w.xscale().bits(opts.vector.xscale.value) } );
-            vscope.yscale().write(|w| unsafe { w.yscale().bits(opts.vector.yscale.value) } );
+            vscope.xscale().write(|w| unsafe { w.scale().bits(opts.vector.xscale.value) } );
+            vscope.yscale().write(|w| unsafe { w.scale().bits(opts.vector.yscale.value) } );
 
             if !help_screen {
                 for ix in 0usize..N_VOICES {

--- a/gateware/src/top/polysyn/fw/src/options.rs
+++ b/gateware/src/top/polysyn/fw/src/options.rs
@@ -42,7 +42,7 @@ int_params!(PageNumParams<u16>    { step: 1, min: 0, max: 0 });
 int_params!(DriveParams<u16>      { step: 2048, min: 0, max: 32768 });
 int_params!(ResoParams<u16>       { step: 2048, min: 8192, max: 32768 });
 int_params!(DiffuseParams<u16>    { step: 2048, min: 0, max: 32768 });
-int_params!(PersistParams<u16>    { step: 64, min: 64, max: 4096 });
+int_params!(PersistParams<u16>    { step: 32, min: 32, max: 4096 });
 int_params!(DecayParams<u8>       { step: 1, min: 0, max: 15 });
 int_params!(IntensityParams<u8>   { step: 1, min: 0, max: 15 });
 int_params!(HueParams<u8>         { step: 1, min: 0, max: 15 });
@@ -79,11 +79,11 @@ pub struct VectorOpts {
 
 #[derive(OptionPage, Clone)]
 pub struct BeamOpts {
-    #[option(128)]
+    #[option(32)]
     pub persist: IntOption<PersistParams>,
     #[option(1)]
     pub decay: IntOption<DecayParams>,
-    #[option(8)]
+    #[option(2)]
     pub intensity: IntOption<IntensityParams>,
     #[option(10)]
     pub hue: IntOption<HueParams>,

--- a/gateware/src/top/polysyn/fw/src/options.rs
+++ b/gateware/src/top/polysyn/fw/src/options.rs
@@ -71,19 +71,19 @@ pub struct PolyOpts {
 
 #[derive(OptionPage, Clone)]
 pub struct VectorOpts {
-    #[option(7)]
+    #[option(6)]
     pub xscale: IntOption<XScaleParams>,
-    #[option(7)]
+    #[option(6)]
     pub yscale: IntOption<YScaleParams>,
 }
 
 #[derive(OptionPage, Clone)]
 pub struct BeamOpts {
-    #[option(32)]
+    #[option(64)]
     pub persist: IntOption<PersistParams>,
-    #[option(1)]
-    pub decay: IntOption<DecayParams>,
     #[option(2)]
+    pub decay: IntOption<DecayParams>,
+    #[option(8)]
     pub intensity: IntOption<IntensityParams>,
     #[option(10)]
     pub hue: IntOption<HueParams>,

--- a/gateware/src/top/usb_audio/top.py
+++ b/gateware/src/top/usb_audio/top.py
@@ -47,38 +47,17 @@ class USBAudioTop(Elaboratable):
             # https://github.com/apfaudio/tiliqua/issues/113
 
             test_signal = Signal(16, reset=0xFEED)
-            pmod_sample_o0 = Signal(16)
 
-            m.d.comb += pmod_sample_o0.eq(pmod0.sample_o[0])
+            pmod_sample_o0 = Signal(16)
+            m.d.comb += pmod_sample_o0.eq(pmod0.i_cal.payload[0])
 
             ila_signals = [
                 test_signal,
                 pmod_sample_o0,
-                pmod0.fs_strobe,
-                m.submodules.audio_to_channels.dac_fifo_level,
-
-                # channel stream
-                #usb_to_channel_stream.channel_stream_out.channel_nr,
-                #usb_to_channel_stream.channel_stream_out.payload,
-                #usb_to_channel_stream.channel_stream_out.valid,
-                #usb_to_channel_stream.garbage_seen_out,
-
-                # interface from IsochronousStreamOutEndpoint
-                #usb_to_channel_stream.usb_stream_in.first,
-                #usb_to_channel_stream.usb_stream_in.valid,
-                #usb_to_channel_stream.usb_stream_in.payload,
-                #usb_to_channel_stream.usb_stream_in.last,
-                #usb_to_channel_stream.usb_stream_in.ready,
-
-                # interface to IsochronousStreamOutEndpoint
-                #ep1_out.interface.rx.next,
-                #ep1_out.interface.rx.valid,
-                #ep1_out.interface.rx.payload,
-
-                usb.sof_detected,
-                sof_counter,
-                feedbackValue,
-                bitPos,
+                pmod0.i_cal.valid,
+                usbif.dbg.dac_fifo_level,
+                usbif.dbg.adc_fifo_level,
+                usbif.dbg.sof_detected,
             ]
 
             self.ila = AsyncSerialILA(signals=ila_signals,
@@ -87,8 +66,7 @@ class USBAudioTop(Elaboratable):
             m.submodules += self.ila
 
             m.d.comb += [
-                self.ila.trigger.eq(pmod0.sample_o[0] > Const(1000)),
-                #self.ila.trigger.eq(usb_audio_in_active),
+                self.ila.trigger.eq((pmod_sample_o0 > Const(1000)) & pmod0.i_cal.valid),
                 platform.request("uart").tx.o.eq(self.ila.tx), # needs FFSync?
             ]
 

--- a/gateware/src/top/usb_audio/top.py
+++ b/gateware/src/top/usb_audio/top.py
@@ -35,7 +35,8 @@ class USBAudioTop(Elaboratable):
         wiring.connect(m, pmod0.pins, pmod0_provider.pins)
         m.d.comb += pmod0.codec_mute.eq(reboot.mute)
 
-        m.submodules.usbif = usbif = usb_audio.USB2AudioInterface()
+        m.submodules.usbif = usbif = usb_audio.USB2AudioInterface(
+                audio_clock=self.clock_settings.audio_clock, nr_channels=4)
 
         wiring.connect(m, pmod0.o_cal, usbif.i)
         wiring.connect(m, usbif.o, pmod0.i_cal)

--- a/gateware/src/top/usb_audio/top.py
+++ b/gateware/src/top/usb_audio/top.py
@@ -58,6 +58,11 @@ class USBAudioTop(Elaboratable):
                 usbif.dbg.dac_fifo_level,
                 usbif.dbg.adc_fifo_level,
                 usbif.dbg.sof_detected,
+                usbif.dbg.channel_stream_out_valid,
+                usbif.dbg.channel_stream_out_first,
+                usbif.dbg.usb_stream_in_valid,
+                usbif.dbg.usb_stream_in_payload,
+                usbif.dbg.usb_stream_in_ready,
             ]
 
             self.ila = AsyncSerialILA(signals=ila_signals,

--- a/gateware/src/top/xbeam/fw/src/main.rs
+++ b/gateware/src/top/xbeam/fw/src/main.rs
@@ -68,6 +68,8 @@ fn main() -> ! {
         modeline.clone(),
     );
 
+    let psram = peripherals.PSRAM_CSR;
+
     let mut i2cdev1 = I2c1::new(peripherals.I2C1);
     let mut pmod = EurorackPmod0::new(peripherals.PMOD0_PERIPH);
     CalibrationConstants::load_or_default(&mut i2cdev1, &mut pmod);
@@ -77,6 +79,8 @@ fn main() -> ! {
     let app = Mutex::new(RefCell::new(App::new(opts)));
 
     handler!(timer0 = || timer0_handler(&app));
+
+    let mut md = 0;
 
     irq::scope(|s| {
 
@@ -94,6 +98,23 @@ fn main() -> ! {
         let v_active = display.size().height;
 
         loop {
+
+            if md % 10 == 0 {
+                psram.ctrl().write(|w| w.collect().bit(false));
+                let cycles_elapsed: u32 = psram.stats0().read().cycles_elapsed().bits();
+                let cycles_idle: u32 = psram.stats1().read().cycles_idle().bits();
+                let cycles_ack_r: u32 = psram.stats2().read().cycles_ack_r().bits();
+                let cycles_ack_w: u32 = psram.stats3().read().cycles_ack_w().bits();
+                psram.ctrl().write(|w| w.collect().bit(true));
+                let sysclk = pac::clock::sysclk();
+                info!("psram [busy={}%, wasted={}%, read={}%, write={}%, refresh={}Hz]",
+                      (100.0f32 * (1.0f32 - (cycles_idle as f32 / cycles_elapsed as f32))) as u32,
+                      (100.0f32 * (cycles_elapsed - cycles_idle - cycles_ack_r - cycles_ack_w) as f32 / cycles_elapsed as f32) as u32,
+                      (100.0f32 * cycles_ack_r as f32 / cycles_elapsed as f32) as u32,
+                      (100.0f32 * cycles_ack_w as f32 / cycles_elapsed as f32) as u32,
+                      sysclk / (cycles_elapsed+1));
+            }
+            md = md + 1;
 
             let (opts, draw_options) = critical_section::with(|cs| {
                 let ui = &app.borrow_ref(cs).ui;

--- a/gateware/src/top/xbeam/fw/src/main.rs
+++ b/gateware/src/top/xbeam/fw/src/main.rs
@@ -148,7 +148,19 @@ fn main() -> ! {
             scope.trigger_lvl().write(|w| unsafe { w.trigger_level().bits(opts.scope.trig_lvl.value as u16) } );
             scope.xscale().write(|w| unsafe { w.xscale().bits(opts.scope.xscale.value) } );
             scope.yscale().write(|w| unsafe { w.yscale().bits(opts.scope.yscale.value) } );
-            scope.timebase().write(|w| unsafe { w.timebase().bits(opts.scope.timebase.value) } );
+            let timebase_value = match opts.scope.timebase.value {
+                Timebase::Timebase1s    => 3,
+                Timebase::Timebase500ms => 6,
+                Timebase::Timebase250ms => 13,
+                Timebase::Timebase100ms => 32,
+                Timebase::Timebase50ms  => 64,
+                Timebase::Timebase25ms  => 128,
+                Timebase::Timebase10ms  => 320,
+                Timebase::Timebase5ms   => 640,
+                Timebase::Timebase2p5ms => 1280,
+                Timebase::Timebase1ms   => 3200,
+            };
+            scope.timebase().write(|w| unsafe { w.timebase().bits(timebase_value) } );
 
             scope.ypos0().write(|w| unsafe { w.ypos().bits(opts.scope.ypos0.value as u16) } );
             scope.ypos1().write(|w| unsafe { w.ypos().bits(opts.scope.ypos1.value as u16) } );

--- a/gateware/src/top/xbeam/fw/src/main.rs
+++ b/gateware/src/top/xbeam/fw/src/main.rs
@@ -137,8 +137,10 @@ fn main() -> ! {
 
             vscope.hue().write(|w| unsafe { w.hue().bits(opts.beam.hue.value) } );
             vscope.intensity().write(|w| unsafe { w.intensity().bits(opts.beam.intensity.value) } );
-            vscope.xscale().write(|w| unsafe { w.xscale().bits(opts.vector.xscale.value) } );
-            vscope.yscale().write(|w| unsafe { w.yscale().bits(opts.vector.yscale.value) } );
+            vscope.xscale().write(|w| unsafe { w.scale().bits(opts.vector.xscale.value) } );
+            vscope.yscale().write(|w| unsafe { w.scale().bits(opts.vector.yscale.value) } );
+            vscope.pscale().write(|w| unsafe { w.scale().bits(opts.vector.pscale.value) } );
+            vscope.cscale().write(|w| unsafe { w.scale().bits(opts.vector.cscale.value) } );
 
             scope.hue().write(|w| unsafe { w.hue().bits(opts.beam.hue.value) } );
             scope.intensity().write(|w| unsafe { w.intensity().bits(opts.beam.intensity.value) } );

--- a/gateware/src/top/xbeam/fw/src/main.rs
+++ b/gateware/src/top/xbeam/fw/src/main.rs
@@ -174,6 +174,11 @@ fn main() -> ! {
                       w.show_outputs().bit(opts.usb.show.value == Show::Outputs)
                 } );
 
+            xbeam_mux.delay0().write(|w| unsafe { w.value().bits(opts.delay.delay_x.value) });
+            xbeam_mux.delay1().write(|w| unsafe { w.value().bits(opts.delay.delay_y.value) });
+            xbeam_mux.delay2().write(|w| unsafe { w.value().bits(opts.delay.delay_i.value) });
+            xbeam_mux.delay3().write(|w| unsafe { w.value().bits(opts.delay.delay_c.value) });
+
             if opts.tracker.page.value == Page::Vector {
                 scope.flags().write(
                     |w| w.enable().bit(false) );

--- a/gateware/src/top/xbeam/fw/src/main.rs
+++ b/gateware/src/top/xbeam/fw/src/main.rs
@@ -127,30 +127,30 @@ fn main() -> ! {
             }
 
             if draw_options {
-                draw::draw_options(&mut display, &opts, h_active-200, v_active/2, opts.beam.hue.value).ok();
-                draw::draw_name(&mut display, h_active/2, v_active-50, opts.beam.hue.value, UI_NAME, UI_SHA,
+                draw::draw_options(&mut display, &opts, h_active-200, v_active/2, opts.beam.ui_hue.value).ok();
+                draw::draw_name(&mut display, h_active/2, v_active-50, opts.beam.ui_hue.value, UI_NAME, UI_SHA,
                                 &modeline).ok();
             }
 
             persist.set_persist(opts.beam.persist.value);
             persist.set_decay(opts.beam.decay.value);
 
-            vscope.hue().write(|w| unsafe { w.hue().bits(opts.beam.hue.value) } );
-            vscope.intensity().write(|w| unsafe { w.intensity().bits(opts.beam.intensity.value) } );
             vscope.xoffset().write(|w| unsafe { w.value().bits(opts.vector.x_offset.value as u16) } );
             vscope.yoffset().write(|w| unsafe { w.value().bits(opts.vector.y_offset.value as u16) } );
-            vscope.xscale().write(|w| unsafe { w.scale().bits(opts.vector.x_scale.value) } );
-            vscope.yscale().write(|w| unsafe { w.scale().bits(opts.vector.y_scale.value) } );
-            vscope.pscale().write(|w| unsafe { w.scale().bits(0xf-opts.vector.i_mod.value) } );
-            vscope.cscale().write(|w| unsafe { w.scale().bits(0xf-opts.vector.c_mod.value) } );
+            vscope.xscale().write(|w| unsafe { w.scale().bits(0xf-opts.vector.x_scale.value) } );
+            vscope.yscale().write(|w| unsafe { w.scale().bits(0xf-opts.vector.y_scale.value) } );
+            vscope.pscale().write(|w| unsafe { w.scale().bits(0xf-opts.vector.i_scale.value) } );
+            vscope.intensity().write(|w| unsafe { w.intensity().bits(opts.vector.i_offset.value) } );
+            vscope.cscale().write(|w| unsafe { w.scale().bits(0xf-opts.vector.c_scale.value) } );
+            vscope.hue().write(|w| unsafe { w.hue().bits(opts.vector.c_offset.value) } );
 
-            scope.hue().write(|w| unsafe { w.hue().bits(opts.beam.hue.value) } );
-            scope.intensity().write(|w| unsafe { w.intensity().bits(opts.beam.intensity.value) } );
+            scope.hue().write(|w| unsafe { w.hue().bits(opts.scope1.hue.value) } );
+            scope.intensity().write(|w| unsafe { w.intensity().bits(opts.scope1.intensity.value) } );
 
-            scope.trigger_lvl().write(|w| unsafe { w.trigger_level().bits(opts.scope.trig_lvl.value as u16) } );
-            scope.xscale().write(|w| unsafe { w.xscale().bits(opts.scope.xscale.value) } );
-            scope.yscale().write(|w| unsafe { w.yscale().bits(opts.scope.yscale.value) } );
-            let timebase_value = match opts.scope.timebase.value {
+            scope.trigger_lvl().write(|w| unsafe { w.trigger_level().bits(opts.scope1.trig_lvl.value as u16) } );
+            scope.xscale().write(|w| unsafe { w.xscale().bits(0xf-opts.scope1.xscale.value) } );
+            scope.yscale().write(|w| unsafe { w.yscale().bits(0xf-opts.scope1.yscale.value) } );
+            let timebase_value = match opts.scope1.timebase.value {
                 Timebase::Timebase1s    => 3,
                 Timebase::Timebase500ms => 6,
                 Timebase::Timebase250ms => 13,
@@ -164,10 +164,10 @@ fn main() -> ! {
             };
             scope.timebase().write(|w| unsafe { w.timebase().bits(timebase_value) } );
 
-            scope.ypos0().write(|w| unsafe { w.ypos().bits(opts.scope.ypos0.value as u16) } );
-            scope.ypos1().write(|w| unsafe { w.ypos().bits(opts.scope.ypos1.value as u16) } );
-            scope.ypos2().write(|w| unsafe { w.ypos().bits(opts.scope.ypos2.value as u16) } );
-            scope.ypos3().write(|w| unsafe { w.ypos().bits(opts.scope.ypos3.value as u16) } );
+            scope.ypos0().write(|w| unsafe { w.ypos().bits(opts.scope2.ypos0.value as u16) } );
+            scope.ypos1().write(|w| unsafe { w.ypos().bits(opts.scope2.ypos1.value as u16) } );
+            scope.ypos2().write(|w| unsafe { w.ypos().bits(opts.scope2.ypos2.value as u16) } );
+            scope.ypos3().write(|w| unsafe { w.ypos().bits(opts.scope2.ypos3.value as u16) } );
 
             xbeam_mux.flags().write(
                 |w| { w.usb_en().bit(opts.usb.mode.value == USBMode::Enable);
@@ -188,11 +188,13 @@ fn main() -> ! {
                     } );
             }
 
-            if opts.tracker.page.value == Page::Scope || first {
+            if opts.tracker.page.value == Page::Scope1 ||
+               opts.tracker.page.value == Page::Scope2 ||
+               first {
                 scope.flags().write(
                     |w| { w.enable().bit(true);
                           w.rotate_left().bit(modeline.rotate == Rotate::Left);
-                          w.trigger_always().bit(opts.scope.trig_mode.value == TriggerMode::Always)
+                          w.trigger_always().bit(opts.scope1.trig_mode.value == TriggerMode::Always)
                     } );
                 vscope.flags().write(
                     |w| w.enable().bit(false) );

--- a/gateware/src/top/xbeam/fw/src/main.rs
+++ b/gateware/src/top/xbeam/fw/src/main.rs
@@ -49,7 +49,6 @@ fn timer0_handler(app: &Mutex<RefCell<App>>) {
 #[entry]
 fn main() -> ! {
     let peripherals = pac::Peripherals::take().unwrap();
-
     let sysclk = pac::clock::sysclk();
     let serial = Serial0::new(peripherals.UART0);
     let mut timer = Timer0::new(peripherals.TIMER0, sysclk);
@@ -86,8 +85,9 @@ fn main() -> ! {
         timer.enable_tick_isr(TIMER0_ISR_PERIOD_MS,
                               pac::Interrupt::TIMER0);
 
-        let vscope  = peripherals.VECTOR_PERIPH;
-        let scope  = peripherals.SCOPE_PERIPH;
+        let vscope    = peripherals.VECTOR_PERIPH;
+        let scope     = peripherals.SCOPE_PERIPH;
+        let xbeam_mux = peripherals.XBEAM_PERIPH;
         let mut first = true;
 
         let h_active = display.size().width;
@@ -131,6 +131,11 @@ fn main() -> ! {
             scope.ypos1().write(|w| unsafe { w.ypos().bits(opts.scope.ypos1.value as u16) } );
             scope.ypos2().write(|w| unsafe { w.ypos().bits(opts.scope.ypos2.value as u16) } );
             scope.ypos3().write(|w| unsafe { w.ypos().bits(opts.scope.ypos3.value as u16) } );
+
+            xbeam_mux.flags().write(
+                |w| { w.usb_bypass().bit(opts.usb.mode.value == USBMode::Bypass);
+                      w.show_outputs().bit(opts.usb.show.value == Show::Outputs)
+                } );
 
             if opts.tracker.page.value == Page::Vector {
                 scope.flags().write(

--- a/gateware/src/top/xbeam/fw/src/main.rs
+++ b/gateware/src/top/xbeam/fw/src/main.rs
@@ -137,10 +137,12 @@ fn main() -> ! {
 
             vscope.hue().write(|w| unsafe { w.hue().bits(opts.beam.hue.value) } );
             vscope.intensity().write(|w| unsafe { w.intensity().bits(opts.beam.intensity.value) } );
-            vscope.xscale().write(|w| unsafe { w.scale().bits(opts.vector.xscale.value) } );
-            vscope.yscale().write(|w| unsafe { w.scale().bits(opts.vector.yscale.value) } );
-            vscope.pscale().write(|w| unsafe { w.scale().bits(opts.vector.pscale.value) } );
-            vscope.cscale().write(|w| unsafe { w.scale().bits(opts.vector.cscale.value) } );
+            vscope.xoffset().write(|w| unsafe { w.value().bits(opts.vector.x_offset.value as u16) } );
+            vscope.yoffset().write(|w| unsafe { w.value().bits(opts.vector.y_offset.value as u16) } );
+            vscope.xscale().write(|w| unsafe { w.scale().bits(opts.vector.x_scale.value) } );
+            vscope.yscale().write(|w| unsafe { w.scale().bits(opts.vector.y_scale.value) } );
+            vscope.pscale().write(|w| unsafe { w.scale().bits(0xf-opts.vector.i_mod.value) } );
+            vscope.cscale().write(|w| unsafe { w.scale().bits(0xf-opts.vector.c_mod.value) } );
 
             scope.hue().write(|w| unsafe { w.hue().bits(opts.beam.hue.value) } );
             scope.intensity().write(|w| unsafe { w.intensity().bits(opts.beam.intensity.value) } );
@@ -168,7 +170,7 @@ fn main() -> ! {
             scope.ypos3().write(|w| unsafe { w.ypos().bits(opts.scope.ypos3.value as u16) } );
 
             xbeam_mux.flags().write(
-                |w| { w.usb_bypass().bit(opts.usb.mode.value == USBMode::Bypass);
+                |w| { w.usb_en().bit(opts.usb.mode.value == USBMode::Enable);
                       w.show_outputs().bit(opts.usb.show.value == Show::Outputs)
                 } );
 

--- a/gateware/src/top/xbeam/fw/src/options.rs
+++ b/gateware/src/top/xbeam/fw/src/options.rs
@@ -64,7 +64,7 @@ pub enum Timebase {
 
 int_params!(ScaleParams<u8>       { step: 1, min: 0, max: 15 });
 int_params!(PCScaleParams<u8>     { step: 1, min: 0, max: 15 });
-int_params!(PersistParams<u16>    { step: 16, min: 16, max: 4096 });
+int_params!(PersistParams<u16>    { step: 32, min: 32, max: 4096 });
 int_params!(DecayParams<u8>       { step: 1, min: 0, max: 15 });
 int_params!(IntensityParams<u8>   { step: 1, min: 0, max: 15 });
 int_params!(HueParams<u8>         { step: 1, min: 0, max: 15 });
@@ -89,11 +89,11 @@ pub struct VectorOpts {
 
 #[derive(OptionPage, Clone)]
 pub struct BeamOpts {
-    #[option(64)]
+    #[option(32)]
     pub persist: IntOption<PersistParams>,
-    #[option(2)]
+    #[option(1)]
     pub decay: IntOption<DecayParams>,
-    #[option(4)]
+    #[option(2)]
     pub intensity: IntOption<IntensityParams>,
     #[option(10)]
     pub hue: IntOption<HueParams>,

--- a/gateware/src/top/xbeam/fw/src/options.rs
+++ b/gateware/src/top/xbeam/fw/src/options.rs
@@ -91,9 +91,9 @@ pub struct VectorOpts {
 pub struct BeamOpts {
     #[option(32)]
     pub persist: IntOption<PersistParams>,
-    #[option(1)]
-    pub decay: IntOption<DecayParams>,
     #[option(2)]
+    pub decay: IntOption<DecayParams>,
+    #[option(4)]
     pub intensity: IntOption<IntensityParams>,
     #[option(10)]
     pub hue: IntOption<HueParams>,

--- a/gateware/src/top/xbeam/fw/src/options.rs
+++ b/gateware/src/top/xbeam/fw/src/options.rs
@@ -19,6 +19,22 @@ pub enum TriggerMode {
     Rising,
 }
 
+#[derive(Default, Clone, Copy, PartialEq, EnumIter, IntoStaticStr)]
+#[strum(serialize_all = "kebab-case")]
+pub enum USBMode {
+    #[default]
+    Bypass,
+    Enable,
+}
+
+#[derive(Default, Clone, Copy, PartialEq, EnumIter, IntoStaticStr)]
+#[strum(serialize_all = "kebab-case")]
+pub enum Show {
+    #[default]
+    Inputs,
+    Outputs,
+}
+
 int_params!(XScaleParams<u8>      { step: 1, min: 0, max: 15 });
 int_params!(YScaleParams<u8>      { step: 1, min: 0, max: 15 });
 int_params!(PersistParams<u16>    { step: 64, min: 64, max: 4096 });

--- a/gateware/src/top/xbeam/fw/src/options.rs
+++ b/gateware/src/top/xbeam/fw/src/options.rs
@@ -36,8 +36,7 @@ pub enum Show {
     Outputs,
 }
 
-int_params!(XScaleParams<u8>      { step: 1, min: 0, max: 15 });
-int_params!(YScaleParams<u8>      { step: 1, min: 0, max: 15 });
+int_params!(ScaleParams<u8>      { step: 1, min: 0, max: 15 });
 int_params!(PersistParams<u16>    { step: 16, min: 16, max: 4096 });
 int_params!(DecayParams<u8>       { step: 1, min: 0, max: 15 });
 int_params!(IntensityParams<u8>   { step: 1, min: 0, max: 15 });
@@ -49,9 +48,13 @@ int_params!(YPosParams<i16>       { step: 25, min: -500, max: 500 });
 #[derive(OptionPage, Clone)]
 pub struct VectorOpts {
     #[option(6)]
-    pub xscale: IntOption<XScaleParams>,
+    pub xscale: IntOption<ScaleParams>,
     #[option(6)]
-    pub yscale: IntOption<YScaleParams>,
+    pub yscale: IntOption<ScaleParams>,
+    #[option(10)]
+    pub pscale: IntOption<ScaleParams>,
+    #[option(10)]
+    pub cscale: IntOption<ScaleParams>,
 }
 
 #[derive(OptionPage, Clone)]
@@ -93,9 +96,9 @@ pub struct ScopeOpts {
     #[option(250)]
     pub ypos3: IntOption<YPosParams>,
     #[option(8)]
-    pub yscale: IntOption<YScaleParams>,
+    pub yscale: IntOption<ScaleParams>,
     #[option(6)]
-    pub xscale: IntOption<XScaleParams>,
+    pub xscale: IntOption<ScaleParams>,
 }
 
 #[derive(Options, Clone, Default)]

--- a/gateware/src/top/xbeam/fw/src/options.rs
+++ b/gateware/src/top/xbeam/fw/src/options.rs
@@ -7,6 +7,7 @@ use tiliqua_lib::palette::ColorPalette;
 pub enum Page {
     Vector,
     Beam,
+    Usb,
     #[default]
     Scope,
 }
@@ -68,6 +69,14 @@ pub struct BeamOpts {
 }
 
 #[derive(OptionPage, Clone)]
+pub struct UsbOpts {
+    #[option]
+    pub mode: EnumOption<USBMode>,
+    #[option]
+    pub show: EnumOption<Show>,
+}
+
+#[derive(OptionPage, Clone)]
 pub struct ScopeOpts {
     #[option(32)]
     pub timebase: IntOption<TimebaseParams>,
@@ -96,6 +105,8 @@ pub struct Opts {
     pub vector: VectorOpts,
     #[page(Page::Beam)]
     pub beam: BeamOpts,
+    #[page(Page::Usb)]
+    pub usb: UsbOpts,
     #[page(Page::Scope)]
     pub scope: ScopeOpts,
 }

--- a/gateware/src/top/xbeam/fw/src/options.rs
+++ b/gateware/src/top/xbeam/fw/src/options.rs
@@ -6,6 +6,7 @@ use tiliqua_lib::palette::ColorPalette;
 #[strum(serialize_all = "SCREAMING-KEBAB-CASE")]
 pub enum Page {
     Vector,
+    Delay,
     Beam,
     Usb,
     #[default]
@@ -62,6 +63,7 @@ pub enum Timebase {
     Timebase1ms,
 }
 
+int_params!(DelayParams<u16>      { step: 128, min: 0, max: 4096 });
 int_params!(ScaleParams<u8>       { step: 1, min: 0, max: 15 });
 int_params!(PCScaleParams<u8>     { step: 1, min: 0, max: 15 });
 int_params!(PersistParams<u16>    { step: 32, min: 32, max: 4096 });
@@ -85,6 +87,18 @@ pub struct VectorOpts {
     pub i_mod: IntOption<PCScaleParams>,
     #[option(0)]
     pub c_mod: IntOption<PCScaleParams>,
+}
+
+#[derive(OptionPage, Clone)]
+pub struct DelayOpts {
+    #[option(0)]
+    pub delay_x: IntOption<DelayParams>,
+    #[option(0)]
+    pub delay_y: IntOption<DelayParams>,
+    #[option(0)]
+    pub delay_i: IntOption<DelayParams>,
+    #[option(0)]
+    pub delay_c: IntOption<DelayParams>,
 }
 
 #[derive(OptionPage, Clone)]
@@ -136,6 +150,8 @@ pub struct Opts {
     pub tracker: ScreenTracker<Page>,
     #[page(Page::Vector)]
     pub vector: VectorOpts,
+    #[page(Page::Delay)]
+    pub delay: DelayOpts,
     #[page(Page::Beam)]
     pub beam: BeamOpts,
     #[page(Page::Usb)]

--- a/gateware/src/top/xbeam/fw/src/options.rs
+++ b/gateware/src/top/xbeam/fw/src/options.rs
@@ -10,7 +10,8 @@ pub enum Page {
     Beam,
     Usb,
     #[default]
-    Scope,
+    Scope1,
+    Scope2,
 }
 
 #[derive(Default, Clone, Copy, PartialEq, EnumIter, IntoStaticStr)]
@@ -77,16 +78,20 @@ int_params!(PosParams<i16>       { step: 25, min: -500, max: 500 });
 pub struct VectorOpts {
     #[option(0)]
     pub x_offset: IntOption<PosParams>,
+    #[option(9)]
+    pub x_scale: IntOption<ScaleParams>,
     #[option(0)]
     pub y_offset: IntOption<PosParams>,
-    #[option(6)]
-    pub x_scale: IntOption<ScaleParams>,
-    #[option(6)]
+    #[option(9)]
     pub y_scale: IntOption<ScaleParams>,
+    #[option(4)]
+    pub i_offset: IntOption<IntensityParams>,
     #[option(0)]
-    pub i_mod: IntOption<PCScaleParams>,
+    pub i_scale: IntOption<PCScaleParams>,
+    #[option(10)]
+    pub c_offset: IntOption<HueParams>,
     #[option(0)]
-    pub c_mod: IntOption<PCScaleParams>,
+    pub c_scale: IntOption<PCScaleParams>,
 }
 
 #[derive(OptionPage, Clone)]
@@ -107,10 +112,8 @@ pub struct BeamOpts {
     pub persist: IntOption<PersistParams>,
     #[option(2)]
     pub decay: IntOption<DecayParams>,
-    #[option(4)]
-    pub intensity: IntOption<IntensityParams>,
     #[option(10)]
-    pub hue: IntOption<HueParams>,
+    pub ui_hue: IntOption<HueParams>,
     #[option]
     pub palette: EnumOption<ColorPalette>,
 }
@@ -124,13 +127,25 @@ pub struct UsbOpts {
 }
 
 #[derive(OptionPage, Clone)]
-pub struct ScopeOpts {
+pub struct ScopeOpts1 {
     #[option]
     pub timebase: EnumOption<Timebase>,
     #[option]
     pub trig_mode: EnumOption<TriggerMode>,
     #[option]
     pub trig_lvl: IntOption<TriggerLvlParams>,
+    #[option(6)]
+    pub yscale: IntOption<ScaleParams>,
+    #[option(9)]
+    pub xscale: IntOption<ScaleParams>,
+    #[option(8)]
+    pub intensity: IntOption<IntensityParams>,
+    #[option(10)]
+    pub hue: IntOption<HueParams>,
+}
+
+#[derive(OptionPage, Clone)]
+pub struct ScopeOpts2 {
     #[option(-250)]
     pub ypos0: IntOption<PosParams>,
     #[option(-75)]
@@ -139,10 +154,6 @@ pub struct ScopeOpts {
     pub ypos2: IntOption<PosParams>,
     #[option(250)]
     pub ypos3: IntOption<PosParams>,
-    #[option(8)]
-    pub yscale: IntOption<ScaleParams>,
-    #[option(6)]
-    pub xscale: IntOption<ScaleParams>,
 }
 
 #[derive(Options, Clone, Default)]
@@ -156,6 +167,8 @@ pub struct Opts {
     pub beam: BeamOpts,
     #[page(Page::Usb)]
     pub usb: UsbOpts,
-    #[page(Page::Scope)]
-    pub scope: ScopeOpts,
+    #[page(Page::Scope1)]
+    pub scope1: ScopeOpts1,
+    #[page(Page::Scope2)]
+    pub scope2: ScopeOpts2,
 }

--- a/gateware/src/top/xbeam/fw/src/options.rs
+++ b/gateware/src/top/xbeam/fw/src/options.rs
@@ -64,7 +64,7 @@ pub enum Timebase {
     Timebase1ms,
 }
 
-int_params!(DelayParams<u16>      { step: 128, min: 0, max: 4096 });
+int_params!(DelayParams<u16>      { step: 32, min: 0, max: 1024 });
 int_params!(ScaleParams<u8>       { step: 1, min: 0, max: 15 });
 int_params!(PCScaleParams<u8>     { step: 1, min: 0, max: 15 });
 int_params!(PersistParams<u16>    { step: 32, min: 32, max: 4096 });
@@ -110,7 +110,7 @@ pub struct DelayOpts {
 pub struct BeamOpts {
     #[option(32)]
     pub persist: IntOption<PersistParams>,
-    #[option(2)]
+    #[option(1)]
     pub decay: IntOption<DecayParams>,
     #[option(10)]
     pub ui_hue: IntOption<HueParams>,

--- a/gateware/src/top/xbeam/fw/src/options.rs
+++ b/gateware/src/top/xbeam/fw/src/options.rs
@@ -36,12 +36,37 @@ pub enum Show {
     Outputs,
 }
 
-int_params!(ScaleParams<u8>      { step: 1, min: 0, max: 15 });
+#[derive(Default, Clone, Copy, PartialEq, EnumIter, IntoStaticStr)]
+#[strum(serialize_all = "kebab-case")]
+pub enum Timebase {
+    #[strum(serialize = "1s")]
+    Timebase1s,
+    #[strum(serialize = "500ms")]
+    Timebase500ms,
+    #[strum(serialize = "250ms")]
+    Timebase250ms,
+    #[default]
+    #[strum(serialize = "100ms")]
+    Timebase100ms,
+    #[strum(serialize = "50ms")]
+    Timebase50ms,
+    #[strum(serialize = "25ms")]
+    Timebase25ms,
+    #[strum(serialize = "10ms")]
+    Timebase10ms,
+    #[strum(serialize = "5ms")]
+    Timebase5ms,
+    #[strum(serialize = "2.5ms")]
+    Timebase2p5ms,
+    #[strum(serialize = "1ms")]
+    Timebase1ms,
+}
+
+int_params!(ScaleParams<u8>       { step: 1, min: 0, max: 15 });
 int_params!(PersistParams<u16>    { step: 16, min: 16, max: 4096 });
 int_params!(DecayParams<u8>       { step: 1, min: 0, max: 15 });
 int_params!(IntensityParams<u8>   { step: 1, min: 0, max: 15 });
 int_params!(HueParams<u8>         { step: 1, min: 0, max: 15 });
-int_params!(TimebaseParams<u16>   { step: 128, min: 32, max: 3872 });
 int_params!(TriggerLvlParams<i16> { step: 512, min: -16384, max: 16384 });
 int_params!(YPosParams<i16>       { step: 25, min: -500, max: 500 });
 
@@ -81,8 +106,8 @@ pub struct UsbOpts {
 
 #[derive(OptionPage, Clone)]
 pub struct ScopeOpts {
-    #[option(32)]
-    pub timebase: IntOption<TimebaseParams>,
+    #[option]
+    pub timebase: EnumOption<Timebase>,
     #[option]
     pub trig_mode: EnumOption<TriggerMode>,
     #[option]

--- a/gateware/src/top/xbeam/fw/src/options.rs
+++ b/gateware/src/top/xbeam/fw/src/options.rs
@@ -33,8 +33,8 @@ pub enum USBMode {
 #[derive(Default, Clone, Copy, PartialEq, EnumIter, IntoStaticStr)]
 #[strum(serialize_all = "kebab-case")]
 pub enum Show {
-    #[default]
     Inputs,
+    #[default]
     Outputs,
 }
 
@@ -64,7 +64,7 @@ pub enum Timebase {
     Timebase1ms,
 }
 
-int_params!(DelayParams<u16>      { step: 32, min: 0, max: 1024 });
+int_params!(DelayParams<u16>      { step: 8, min: 0, max: 512 });
 int_params!(ScaleParams<u8>       { step: 1, min: 0, max: 15 });
 int_params!(PCScaleParams<u8>     { step: 1, min: 0, max: 15 });
 int_params!(PersistParams<u16>    { step: 32, min: 32, max: 4096 });

--- a/gateware/src/top/xbeam/fw/src/options.rs
+++ b/gateware/src/top/xbeam/fw/src/options.rs
@@ -38,7 +38,7 @@ pub enum Show {
 
 int_params!(XScaleParams<u8>      { step: 1, min: 0, max: 15 });
 int_params!(YScaleParams<u8>      { step: 1, min: 0, max: 15 });
-int_params!(PersistParams<u16>    { step: 64, min: 64, max: 4096 });
+int_params!(PersistParams<u16>    { step: 16, min: 16, max: 4096 });
 int_params!(DecayParams<u8>       { step: 1, min: 0, max: 15 });
 int_params!(IntensityParams<u8>   { step: 1, min: 0, max: 15 });
 int_params!(HueParams<u8>         { step: 1, min: 0, max: 15 });

--- a/gateware/src/top/xbeam/fw/src/options.rs
+++ b/gateware/src/top/xbeam/fw/src/options.rs
@@ -63,23 +63,28 @@ pub enum Timebase {
 }
 
 int_params!(ScaleParams<u8>       { step: 1, min: 0, max: 15 });
+int_params!(PCScaleParams<u8>     { step: 1, min: 0, max: 15 });
 int_params!(PersistParams<u16>    { step: 16, min: 16, max: 4096 });
 int_params!(DecayParams<u8>       { step: 1, min: 0, max: 15 });
 int_params!(IntensityParams<u8>   { step: 1, min: 0, max: 15 });
 int_params!(HueParams<u8>         { step: 1, min: 0, max: 15 });
 int_params!(TriggerLvlParams<i16> { step: 512, min: -16384, max: 16384 });
-int_params!(YPosParams<i16>       { step: 25, min: -500, max: 500 });
+int_params!(PosParams<i16>       { step: 25, min: -500, max: 500 });
 
 #[derive(OptionPage, Clone)]
 pub struct VectorOpts {
+    #[option(0)]
+    pub x_offset: IntOption<PosParams>,
+    #[option(0)]
+    pub y_offset: IntOption<PosParams>,
     #[option(6)]
-    pub xscale: IntOption<ScaleParams>,
+    pub x_scale: IntOption<ScaleParams>,
     #[option(6)]
-    pub yscale: IntOption<ScaleParams>,
-    #[option(10)]
-    pub pscale: IntOption<ScaleParams>,
-    #[option(10)]
-    pub cscale: IntOption<ScaleParams>,
+    pub y_scale: IntOption<ScaleParams>,
+    #[option(0)]
+    pub i_mod: IntOption<PCScaleParams>,
+    #[option(0)]
+    pub c_mod: IntOption<PCScaleParams>,
 }
 
 #[derive(OptionPage, Clone)]
@@ -113,13 +118,13 @@ pub struct ScopeOpts {
     #[option]
     pub trig_lvl: IntOption<TriggerLvlParams>,
     #[option(-250)]
-    pub ypos0: IntOption<YPosParams>,
+    pub ypos0: IntOption<PosParams>,
     #[option(-75)]
-    pub ypos1: IntOption<YPosParams>,
+    pub ypos1: IntOption<PosParams>,
     #[option(75)]
-    pub ypos2: IntOption<YPosParams>,
+    pub ypos2: IntOption<PosParams>,
     #[option(250)]
-    pub ypos3: IntOption<YPosParams>,
+    pub ypos3: IntOption<PosParams>,
     #[option(8)]
     pub yscale: IntOption<ScaleParams>,
     #[option(6)]

--- a/gateware/src/top/xbeam/fw/src/options.rs
+++ b/gateware/src/top/xbeam/fw/src/options.rs
@@ -56,11 +56,11 @@ pub struct VectorOpts {
 
 #[derive(OptionPage, Clone)]
 pub struct BeamOpts {
-    #[option(128)]
+    #[option(64)]
     pub persist: IntOption<PersistParams>,
-    #[option(1)]
+    #[option(2)]
     pub decay: IntOption<DecayParams>,
-    #[option(8)]
+    #[option(4)]
     pub intensity: IntOption<IntensityParams>,
     #[option(10)]
     pub hue: IntOption<HueParams>,

--- a/gateware/src/top/xbeam/top.py
+++ b/gateware/src/top/xbeam/top.py
@@ -91,7 +91,7 @@ class XbeamSoc(TiliquaSoc):
         self.flusher = cache.CacheFlusher(
                 base=self.fb.fb_base,
                 addr_width=self.psram_periph.bus.addr_width,
-                burst_len=self.cache.burst_len<<5)
+                burst_len=self.cache.burst_len)
         self.arbiter.add(self.flusher.bus)
 
         self.vector_periph = scope.VectorTracePeripheral(

--- a/gateware/src/top/xbeam/top.py
+++ b/gateware/src/top/xbeam/top.py
@@ -122,7 +122,8 @@ class XbeamSoc(TiliquaSoc):
 
         self.scope_periph.source = pmod0.o_cal
 
-        m.submodules.usbif = usbif = usb_audio.USB2AudioInterface()
+        m.submodules.usbif = usbif = usb_audio.USB2AudioInterface(
+                audio_clock=self.clock_settings.audio_clock, nr_channels=4)
 
         with m.If(self.xbeam_periph.usb_bypass):
             wiring.connect(m, pmod0.o_cal, pmod0.i_cal)

--- a/gateware/src/top/xbeam/top.py
+++ b/gateware/src/top/xbeam/top.py
@@ -39,7 +39,7 @@ class XbeamPeripheral(wiring.Component):
         self._flags = regs.add("flags", self.Flags(), offset=0x0)
         self._bridge = csr.Bridge(regs.as_memory_map())
         super().__init__({
-            "usb_bypass": Out(1),
+            "usb_bypass": Out(1, init=1),
             "show_outputs": Out(1),
             "bus": In(csr.Signature(addr_width=regs.addr_width, data_width=regs.data_width)),
         })

--- a/gateware/src/top/xbeam/top.py
+++ b/gateware/src/top/xbeam/top.py
@@ -75,8 +75,7 @@ class XbeamSoc(TiliquaSoc):
 
         self.cache = cache.WishboneL2Cache(
                 addr_width=self.psram_periph.bus.addr_width,
-                cachesize_words=64)
-
+                cachesize_words=32)
 
         self.arbiter = wishbone.Arbiter(
             addr_width=self.psram_periph.bus.addr_width,

--- a/gateware/src/top/xbeam/top.py
+++ b/gateware/src/top/xbeam/top.py
@@ -75,7 +75,7 @@ class XbeamSoc(TiliquaSoc):
 
         self.cache = cache.WishboneL2Cache(
                 addr_width=self.psram_periph.bus.addr_width,
-                cachesize_words=256)
+                cachesize_words=32)
 
         self.arbiter = wishbone.Arbiter(
             addr_width=self.psram_periph.bus.addr_width,

--- a/gateware/src/top/xbeam/top.py
+++ b/gateware/src/top/xbeam/top.py
@@ -28,6 +28,37 @@ from tiliqua                                     import eurorack_pmod, dsp, scop
 from tiliqua.tiliqua_soc                         import TiliquaSoc
 from tiliqua.cli                                 import top_level_cli
 
+class XbeamPeripheral(wiring.Component):
+
+    class Flags(csr.Register, access="w"):
+        usb_bypass:   csr.Field(csr.action.W, unsigned(1))
+        show_outputs: csr.Field(csr.action.W, unsigned(1))
+
+    def __init__(self):
+        regs = csr.Builder(addr_width=5, data_width=8)
+        self._flags = regs.add("flags", self.Flags(), offset=0x0)
+        self._bridge = csr.Bridge(regs.as_memory_map())
+        super().__init__({
+            "usb_bypass": Out(1),
+            "show_outputs": Out(1),
+            "bus": In(csr.Signature(addr_width=regs.addr_width, data_width=regs.data_width)),
+        })
+        self.bus.memory_map = self._bridge.bus.memory_map
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules.bridge  = self._bridge
+        connect(m, flipped(self.bus), self._bridge.bus)
+
+        with m.If(self._flags.f.usb_bypass.w_stb):
+            m.d.sync += self.usb_bypass.eq(self._flags.f.usb_bypass.w_data)
+
+        with m.If(self._flags.f.show_outputs.w_stb):
+            m.d.sync += self.show_outputs.eq(self._flags.f.show_outputs.w_data)
+
+        return m
+
 class XbeamSoc(TiliquaSoc):
 
     brief = "Graphical vectorscope and oscilloscope."
@@ -40,6 +71,7 @@ class XbeamSoc(TiliquaSoc):
         # WARN: TiliquaSoc ends at 0x00000900
         self.vector_periph_base = 0x00001000
         self.scope_periph_base  = 0x00001100
+        self.xbeam_periph_base  = 0x00001200
 
         self.vector_periph = scope.VectorTracePeripheral(
             fb=self.fb,
@@ -50,6 +82,9 @@ class XbeamSoc(TiliquaSoc):
             fb=self.fb,
             bus_dma=self.psram_periph)
         self.csr_decoder.add(self.scope_periph.bus, addr=self.scope_periph_base, name="scope_periph")
+
+        self.xbeam_periph = XbeamPeripheral()
+        self.csr_decoder.add(self.xbeam_periph.bus, addr=self.xbeam_periph_base, name="xbeam_periph")
 
         # now we can freeze the memory map
         self.finalize_csr_bridge()
@@ -62,27 +97,44 @@ class XbeamSoc(TiliquaSoc):
 
         m.submodules += self.scope_periph
 
+        m.submodules += self.xbeam_periph
+
         m.submodules += super().elaborate(platform)
 
         pmod0 = self.pmod0_periph.pmod
 
         self.scope_periph.source = pmod0.o_cal
 
-        #wiring.connect(m, pmod0.o_cal, pmod0.i_cal)
         m.submodules.usbif = usbif = usb_audio.USB2AudioInterface()
-        wiring.connect(m, pmod0.o_cal, usbif.i)
-        wiring.connect(m, usbif.o, pmod0.i_cal)
+
+        with m.If(self.xbeam_periph.usb_bypass):
+            wiring.connect(m, pmod0.o_cal, pmod0.i_cal)
+        with m.Else():
+            wiring.connect(m, pmod0.o_cal, usbif.i)
+            wiring.connect(m, usbif.o, pmod0.i_cal)
 
         with m.If(self.scope_periph.soc_en):
-            m.d.comb += [
-                self.scope_periph.i.valid.eq(pmod0.i_cal.valid & pmod0.i_cal.ready),
-                self.scope_periph.i.payload.eq(pmod0.i_cal.payload),
-            ]
+            with m.If(self.xbeam_periph.show_outputs):
+                m.d.comb += [
+                    self.scope_periph.i.valid.eq(pmod0.i_cal.valid & pmod0.i_cal.ready),
+                    self.scope_periph.i.payload.eq(pmod0.i_cal.payload),
+                ]
+            with m.Else():
+                m.d.comb += [
+                    self.scope_periph.i.valid.eq(pmod0.o_cal.valid & pmod0.o_cal.ready),
+                    self.scope_periph.i.payload.eq(pmod0.o_cal.payload),
+                ]
         with m.Else():
-            m.d.comb += [
-                self.vector_periph.i.valid.eq(pmod0.i_cal.valid & pmod0.i_cal.ready),
-                self.vector_periph.i.payload.eq(pmod0.i_cal.payload),
-            ]
+            with m.If(self.xbeam_periph.show_outputs):
+                m.d.comb += [
+                    self.vector_periph.i.valid.eq(pmod0.i_cal.valid & pmod0.i_cal.ready),
+                    self.vector_periph.i.payload.eq(pmod0.i_cal.payload),
+                ]
+            with m.Else():
+                m.d.comb += [
+                    self.vector_periph.i.valid.eq(pmod0.o_cal.valid & pmod0.o_cal.ready),
+                    self.vector_periph.i.payload.eq(pmod0.o_cal.payload),
+                ]
 
         # Memory controller hangs if we start making requests to it straight away.
         with m.If(self.permit_bus_traffic):

--- a/gateware/src/top/xbeam/top.py
+++ b/gateware/src/top/xbeam/top.py
@@ -75,7 +75,7 @@ class XbeamSoc(TiliquaSoc):
 
         self.cache = cache.WishboneL2Cache(
                 addr_width=self.psram_periph.bus.addr_width,
-                cachesize_words=256)
+                cachesize_words=64)
 
         self.arbiter = wishbone.Arbiter(
             addr_width=self.psram_periph.bus.addr_width,
@@ -95,7 +95,8 @@ class XbeamSoc(TiliquaSoc):
 
         self.vector_periph = scope.VectorTracePeripheral(
             fb=self.fb,
-            bus_dma=self.arbiter)
+            bus_dma=self.arbiter,
+            n_upsample=8)
         self.csr_decoder.add(self.vector_periph.bus, addr=self.vector_periph_base, name="vector_periph")
 
         self.scope_periph = scope.ScopeTracePeripheral(

--- a/gateware/src/top/xbeam/top.py
+++ b/gateware/src/top/xbeam/top.py
@@ -120,8 +120,6 @@ class XbeamSoc(TiliquaSoc):
 
         pmod0 = self.pmod0_periph.pmod
 
-        self.scope_periph.source = pmod0.o_cal
-
         m.submodules.usbif = usbif = usb_audio.USB2AudioInterface(
                 audio_clock=self.clock_settings.audio_clock, nr_channels=4)
 


### PR DESCRIPTION
This PR makes lots of improvements to `xbeam`, while improving some related topics on the way.
# Changes
- Feature: Vastly improved backing cache behind `xbeam` plotting, we can plot about 4x as many points as before.
  - Drawback: some minor caching artifacts visible, I don't think this is a huge deal, will address in followup. Still looks loads better than before regardless :)
- Feature: `xbeam` now has USB audio support (4ch/4ch 192kHz)
  - The audio interface is always present over USB, the menu option just selects whether the audio streams from the USB interface are routed to Tiliqua's jacks or not. This allows instant switching between USB or local analog signals. By default the USB streams are bypassed and are not routed to Tiliqua's inputs/outputs.
- Feature: `xbeam` vectorscope now fully supports color and intensity modulation (both off by default with zero scale)
- Feature: `xbeam` now has 4 tunable delay lines in the output path (all zero by default), these can be used for visualizing mono signals or adding interesting color patterns, by using a mult to send the same signal to multiple sources (for example, send a mono signal to x and y with a mult, then add some delay on y to create interesting patterns.)
- Feature: Timebase menu option is exponential rather than linear, like a real scope
- Feature: Slower timebases are now supported
- Feature: Hue/intensity for UI/Scope/Vectorscope now all have separate options
- Bugfix: Fix scope vertical polarity being inverted when screen is rotated
- Bugfix: Fix USB feedback endpoint at high sample rates (192kHz)
- Bugfix: Cut timing in stroke/raster to reduce intensity glitches
- Bugfix: Fix BRAM inference in cache backing store
- Bugfix: Add periodic CacheFlusher to all usage of write-back cache for plotting purposes.
- Bugfix: Switch from combinatorial IO to IO Registers (FFBuffer) on all I2S lines except MCLK. This fixes some spurious dropouts at high MCLK (50MHz), likely caused by us not meeting timing on the I2S bus.