### PR TITLE
dsp/eurorack_pmod: add example of external expansion boards

### DIFF
--- a/gateware/src/tiliqua/tiliqua_platform.py
+++ b/gateware/src/tiliqua/tiliqua_platform.py
@@ -395,7 +395,7 @@ class _TiliquaR4Mobo:
 
     # Expansion connectors ex0 and ex1
     connectors  = [
-        Connector("pmod", 0, "55 38 66 41 - - 57 35 34 70 - -", conn=("m2", 0)),
+        Connector("pmod", 0, "55 38 66 41 - - 57 35 34 73 - -", conn=("m2", 0)),
         Connector("pmod", 1, "59 63 14 20 - - 61 15 13 22 - -", conn=("m2", 0)),
     ]
 


### PR DESCRIPTION
- Fix a pinout error on the R4 motherboard expansion port assignments
- Add support for extra audio boards connected through the PMOD ports
- Add a simple `TripleMirror` demo to `top/dsp` that sends inputs to outputs on 3 audio boards simultaneously (1x internal + 2x external)