### PR TITLE
dsp/fft: add cores for frequency-domain processing

### DIFF
--- a/gateware/docs/dsp/cordic.rst
+++ b/gateware/docs/dsp/cordic.rst
@@ -1,0 +1,4 @@
+Trigonometry / CORDIC
+---------------------
+
+.. automodule:: tiliqua.cordic

--- a/gateware/docs/dsp/fft.rst
+++ b/gateware/docs/dsp/fft.rst
@@ -1,0 +1,35 @@
+Frequency-domain processing
+---------------------------
+
+FFTs
+^^^^
+
+.. autoclass:: tiliqua.fft.FFT
+
+Windowing
+^^^^^^^^^
+
+.. autoclass:: tiliqua.fft.Window
+
+Overlap / Add
+^^^^^^^^^^^^^
+
+.. autoclass:: tiliqua.fft.ComputeOverlappingBlocks
+
+.. autoclass:: tiliqua.fft.OverlapAddBlocks
+
+STFTs
+^^^^^
+
+.. autoclass:: tiliqua.fft.STFTProcessor
+
+.. autoclass:: tiliqua.fft.STFTAnalyzer
+
+.. autoclass:: tiliqua.fft.STFTSynthesizer
+
+.. autoclass:: tiliqua.fft.STFTProcessorPipelined
+
+Spectral utilities
+^^^^^^^^^^^^^^^^^^
+
+.. automodule:: tiliqua.spectral

--- a/gateware/docs/dsp/index.rst
+++ b/gateware/docs/dsp/index.rst
@@ -24,6 +24,9 @@ DSP Components
    vca
    mix
    resample
+   fft
+   cordic
    oneshot
    stream
    misc
+   types

--- a/gateware/docs/dsp/types.rst
+++ b/gateware/docs/dsp/types.rst
@@ -1,0 +1,12 @@
+Types
+-----
+
+Sample Blocks
+^^^^^^^^^^^^^
+
+.. automodule:: tiliqua.block
+
+Complex Numbers
+^^^^^^^^^^^^^^^
+
+.. automodule:: tiliqua.complex

--- a/gateware/scripts/build_bitstreams_no_soc.sh
+++ b/gateware/scripts/build_bitstreams_no_soc.sh
@@ -20,6 +20,9 @@ parallel --halt now,fail=1 --jobs 0 --ungroup "{} $@" ::: \
   "pdm dsp build --dsp-core=sram_diffuser" \
   "pdm dsp build --dsp-core=multi_diffuser" \
   "pdm dsp build --dsp-core=resampler" \
+  "pdm dsp build --dsp-core=noise" \
+  "pdm dsp build --dsp-core=stft_mirror" \
+  "pdm dsp build --dsp-core=vocoder" \
   "pdm vectorscope_no_soc build --fs-192khz" \
   "pdm bootstub build" \
   "pdm usb_audio build" \

--- a/gateware/src/tiliqua/block.py
+++ b/gateware/src/tiliqua/block.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2024 S. Holzapfel <me@sebholzapfel.com>
+#
+# SPDX-License-Identifier: CERN-OHL-S-2.0
+#
+
+"""Utilities for dealing with contiguous blocks of samples."""
+
+from amaranth import *
+from amaranth.lib import data
+
+class Block(data.StructLayout):
+    """:class:`data.StructLayout` representing a 'Block' of samples.
+
+    shape : Shape
+        Shape of the ``sample`` payload of elements in this block.
+
+    This is normally used in combination with  :class:`stream.Signature`, where
+    ``valid``, ``ready`` and ``payload.first`` are used to delineate samples
+    inside. Blocks are transferred one sample at a time - a practical example
+    with blocks of length 8:
+
+    .. code-block:: text
+
+                         |-- block 1 --| |-- block 2 --| |---
+        payload.sample:  0 1 2 3 4 5 6 7 8 A B C D E F G H I ...
+        payload.first:   -_______________-_______________-__
+        valid:           -_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-_-
+        ready:           (all ones)
+
+    Most cores here are assuming they are working with blocks of some predefined
+    size - that is, each producer/consumer must expect the same size of :class:`Block`.
+
+    Members
+    -------
+    first : :py:`unsigned(1)`
+        Strobe asserted for first sample in a block, deasserted otherwise.
+    sample : :py:`shape`
+        Payload of this sample in the block.
+    """
+    def __init__(self, shape):
+        # TODO: future - add expected size as metadata and verify on wiring.connect ?
+        super().__init__({
+            "first": unsigned(1),
+            "sample": shape
+        })
+
+def connect_without_payload(m, stream_o, stream_i):
+    m.d.comb += [
+        stream_i.valid.eq(stream_o.valid),
+        stream_o.ready.eq(stream_i.ready),
+    ]
+    shape_o = stream_o.payload.shape()
+    shape_i = stream_i.payload.shape()
+    if isinstance(shape_o, Block) or isinstance(shape_i, Block):
+        assert isinstance(shape_o, Block) and isinstance(shape_i, Block)
+        m.d.comb += stream_i.payload.first.eq(stream_o.payload.first)
+

--- a/gateware/src/tiliqua/complex.py
+++ b/gateware/src/tiliqua/complex.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2024 S. Holzapfel <me@sebholzapfel.com>
+#
+# SPDX-License-Identifier: CERN-OHL-S-2.0
+#
+
+"""Utilities for dealing with fixed-point complex numbers."""
+
+from amaranth import *
+from amaranth.lib import data
+from amaranth.lib.wiring import In, Out
+from amaranth_future import fixed
+
+from tiliqua import block
+
+class CQ(data.StructLayout):
+    """:class:`data.StructLayout` representing a complex number, formed by a pair of numbers.
+
+    shape : fixed.SQ
+        Shape of the fixed-point types used for real and imaginary components.
+
+    Members
+    -------
+    real : :py:`shape`
+        Real component of complex number.
+    imag : :py:`shape`
+        Imaginary component of complex number.
+    """
+    def __init__(self, shape: fixed.SQ):
+        super().__init__({
+            "real": shape,
+            "imag": shape,
+        })
+
+class Polar(data.StructLayout):
+    """:class:`data.StructLayout` representing a complex number in polar form.
+
+    shape : fixed.SQ
+        Shape of the fixed-point types used for magnitude and phase components.
+
+    Members
+    -------
+    magnitude : :py:`shape`
+        Magnitude component of complex number.
+    phase : :py:`shape`
+        Phase component of complex number.
+    """
+    def __init__(self, shape: fixed.SQ):
+        super().__init__({
+            "magnitude": shape,
+            "phase": shape,
+        })
+
+def connect_sq_to_real(m, stream_o, stream_i):
+    """Adapter: connect a real ``stream_o`` to a complex ``stream_i``, forwarding
+    only the real component.
+    """
+    block.connect_without_payload(m, stream_o, stream_i)
+    m.d.comb += [
+        stream_i.payload.sample.real.eq(stream_o.payload.sample),
+        stream_i.payload.sample.imag.eq(0),
+    ]
+
+def connect_real_to_sq(m, stream_o, stream_i):
+    """Adapter: connect a complex ``stream_o`` to a real ``stream_i``, forwarding
+    only the real component.
+    """
+    block.connect_without_payload(m, stream_o, stream_i)
+    m.d.comb += [
+        stream_i.payload.sample.eq(stream_o.payload.sample.real),
+    ]
+
+
+def connect_magnitude_to_sq(m, stream_o, stream_i):
+    """Adapter: connect a polar ``stream_o`` to a real ``stream_i``, forwarding
+    only the magnitude component.
+    """
+    block.connect_without_payload(m, stream_o, stream_i)
+    m.d.comb += [
+        stream_i.payload.sample.eq(stream_o.payload.sample.magnitude),
+    ]

--- a/gateware/src/tiliqua/cordic.py
+++ b/gateware/src/tiliqua/cordic.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2024 S. Holzapfel <me@sebholzapfel.com>
+#
+# SPDX-License-Identifier: CERN-OHL-S-2.0
+#
+
+"""Utilities for computing trigonometric functions in hardware."""
+
+from amaranth import *
+from amaranth.lib import wiring, data, stream, memory
+from amaranth.lib.wiring import In, Out
+from amaranth.utils import exact_log2
+
+from amaranth_future import fixed
+
+from math import atan, pi
+
+from tiliqua.complex import CQ, Polar
+from tiliqua.block import Block
+
+class RectToPolarCordic(wiring.Component):
+
+    """Iteratively compute magnitude and phase of complex numbers.
+
+    This core uses a CORDIC (Coordinate Rotation Digital Computer) approach
+    to convert rectangular to polar complex numbers using only shifts and adds.
+
+    This is useful for extracting power spectra from frequency-domain blocks.
+
+    Given a complex number in rectangular coordinates, this core emits:
+
+    .. code-block:: text
+
+        o.payload.magnitude = S*sqrt(i.payload.real**2 + i.payload.imag**2)
+        o.payload.phase     = atan2(i.payload.imag, i.payload.real) / pi
+
+        S: =1 if 'magnitude_correction' is True, and =K (CORDIC gain) otherwise
+
+    Members
+    -------
+    i : :py:`In(stream.Signature(Block(CQ(shape))))`
+        Stream of incoming complex numbers in rectangular coordinates.
+    o : :py:`Out(stream.Signature(Block(Polar(self.internal_shape))))`
+        Stream of outgoing complex numbers in polar coordinates.
+    """
+
+    #: CORDIC gain constant.
+    K = 1.646760258121
+
+    def __init__(self, shape: fixed.Shape, iterations: int = None,
+                 magnitude_correction=True):
+        """
+        shape : Shape
+            Shape of fixed-point number to use for incoming :class:`CQ` stream.
+        iterations : int
+            Number of iterations of computation. Higher is better accuracy, but
+            requires more clock cycles. This defaults to the number of bits
+            in the provided ``shape``.
+        magnitude_correction : bool
+            Whether to consume an additional multiplier to correct for the CORDIC gain
+            constant. For some applications, this is not needed and can be used to
+            save a multiplier.
+        """
+
+        self.shape = shape
+        self.iterations = iterations or shape.i_bits + shape.f_bits
+        self.internal_shape = fixed.SQ(self.shape.i_bits + 2, self.shape.f_bits)
+        self.magnitude_correction = magnitude_correction
+
+        super().__init__({
+            # TODO: Block wrapper should be lifted into dedicated component, as this
+            # core doesn't really need to care about block positions!
+            "i": In(stream.Signature(Block(CQ(shape)))),
+            "o": Out(stream.Signature(Block(Polar(self.internal_shape)))),
+        })
+
+    def elaborate(self, platform) -> Module:
+        m = Module()
+
+        #
+        # Arctangent ROM initialization
+        #
+
+        atan_values = []
+        for i in range(self.iterations):
+            angle = atan(1.0 / (1<<i)) / pi
+            atan_values.append(angle)
+        m.submodules.atan_rom = atan_rom = memory.Memory(
+            shape=self.internal_shape, 
+            depth=self.iterations, 
+            init=atan_values
+        )
+        atan_rd = atan_rom.read_port(domain='comb')
+
+        #
+        # State and iteration registers
+        #
+
+        in_latch = Signal.like(self.i.payload)
+        x = Signal(self.internal_shape)
+        y = Signal(self.internal_shape)
+        z = Signal(self.internal_shape)
+        iteration = Signal(range(self.iterations + 1))
+
+        #
+        # Combinatorial
+        #
+
+        x_shift = Signal(self.internal_shape)
+        y_shift = Signal(self.internal_shape)
+        d = Signal()
+        m.d.comb += [
+            atan_rd.addr.eq(iteration),
+            # Shifted values for current iteration
+            x_shift.eq(x >> iteration),
+            y_shift.eq(y >> iteration),
+            # Direction
+            d.eq((x<0)^(y<0)),
+        ]
+
+        #
+        # Output assignments
+        #
+
+        quadrant_adjust = Signal(self.internal_shape)
+        m.d.comb += self.o.payload.sample.phase.eq(z + quadrant_adjust),
+        m.d.comb += self.o.payload.first.eq(in_latch.first),
+        if self.magnitude_correction:
+            # Scale magnitude by 1/K to compensate for CORDIC gain
+            m.d.comb += self.o.payload.sample.magnitude.eq(
+                x * fixed.Const(1.0/self.K, self.internal_shape))
+        else:
+            m.d.comb += self.o.payload.sample.magnitude.eq(x)
+
+        with m.FSM():
+            with m.State("IDLE"):
+                m.d.comb += self.i.ready.eq(1)
+                with m.If(self.i.valid):
+                    m.d.sync += in_latch.eq(self.i.payload)
+                    m.next = "QUADRANT"
+
+            #
+            # Determine which of 4 quadrants this sample is in
+            #
+
+            with m.State("QUADRANT"):
+                m.d.sync += [
+                    z.eq(0),
+                    iteration.eq(0),
+                    quadrant_adjust.eq(0)
+                ]
+                with m.If((in_latch.sample.real >= 0)):  # Q1, Q4
+                    m.d.sync += [
+                        x.eq(in_latch.sample.real),
+                        y.eq(in_latch.sample.imag),
+                    ]
+                with m.Else():
+                    m.d.sync += [
+                        x.eq(-in_latch.sample.real),
+                        y.eq(-in_latch.sample.imag),
+                    ]
+                    with m.If(in_latch.sample.imag >= 0):
+                        m.d.sync += quadrant_adjust.eq(fixed.Const(1.0))  # Q2
+                    with m.Else():
+                        m.d.sync += quadrant_adjust.eq(fixed.Const(-1.0)) # Q3
+                m.next = "ITERATE"
+
+            #
+            # CORDIC rotation for self.iterations
+            #
+
+            with m.State("ITERATE"):
+                with m.If(iteration < self.iterations):
+                    with m.If(d):  # y >= 0, rotate clockwise
+                        m.d.sync += [
+                            x.eq(x - y_shift),
+                            y.eq(y + x_shift),
+                            z.eq(z - atan_rd.data),
+                        ]
+                    with m.Else():  # y < 0, rotate counter-clockwise
+                        m.d.sync += [
+                            x.eq(x + y_shift),
+                            y.eq(y - x_shift),
+                            z.eq(z + atan_rd.data),
+                        ]
+                    m.d.sync += iteration.eq(iteration + 1)
+                    m.next = "ITERATE"
+                with m.Else():
+                    m.next = "OUTPUT"
+
+            with m.State("OUTPUT"):
+                m.d.comb += self.o.valid.eq(1)
+                with m.If(self.o.ready):
+                    m.next = "IDLE"
+
+        return m

--- a/gateware/src/tiliqua/fft.py
+++ b/gateware/src/tiliqua/fft.py
@@ -1,0 +1,1053 @@
+# Copyright (c) 2024 S. Holzapfel <me@sebholzapfel.com>
+#
+# SPDX-License-Identifier: CERN-OHL-S-2.0
+#
+
+"""Utilities for frequency-domain analysis and synthesis."""
+
+from enum import Enum
+
+from amaranth import *
+from amaranth.lib import memory, wiring, data, stream, fifo
+from amaranth.lib.wiring import In, Out
+from amaranth.utils import exact_log2
+
+from amaranth_future import fixed
+
+from tiliqua.complex import CQ, connect_sq_to_real, connect_real_to_sq
+from tiliqua.block   import Block
+
+from math import cos, sin, pi, sqrt
+
+class FFT(wiring.Component):
+
+    """Fixed-point Fast Fourier Transform.
+
+    Overview
+    --------
+
+    This core computes the DFT of complex, fixed-point samples (specifically,
+    power-of-two chunks, represented by :class:`Block` of :class:`CQ`). It can be run
+    in 'forward' or 'inverse' mode, and is generally designed to match the behaviour
+    of ``scipy.fft(norm="forward")``.
+
+    Input and output samples are clocked in FIFO order. Block processing only begins
+    once ``sz`` elements (an entire block) has been clocked at ``self.i``. Some time
+    later, the core clocks the transformed block out ``self.o``, before clocking in
+    the next block. See the 'Design' section for further details on throughput.
+
+    Switching modes
+    ---------------
+
+    When the core is idle (nothing is clocked into the core and ``i.ready`` is strobed),
+    the ``ifft`` signal may be set to 1 to put the core into 'inverse FFT' mode.
+    Otherwise, it is in 'forward FFT' mode.
+
+        - In forward mode, this FFT core normalizes the outputs by 1/N, and the
+          twiddle factors are not conjugated.
+        - In 'inverse FFT' mode, there is no normalization, and the twiddle factors
+          are conjugated as required.
+
+    Design
+    ------
+
+    There are many tradeoffs an FFT implementation can make. This one aims
+    for low area and DSP tile usage. It is an iterative implementation that
+    only performs 2 multiplies at a time. The core FFT loop takes 6 cycles,
+    where 2 of these are arithmetic and the rest are memory operations.
+    The algorithm implemented here is 'Cooley-Tukey, Decimation-in-Time, Radix-2'.
+
+    Latency, resource usage
+    ^^^^^^^^^^^^^^^^^^^^^^^
+    As this core only performs 2 multiplies at a time, it only requires 2 DSP tiles,
+    assuming the ``shape`` specified is small enough. For 16-bit samples at an
+    FFT size of 1024, the extra bits needed to account for overflow requires 4x
+    18-bit multipliers on an ECP5.
+
+    Outputs take ``sz*log2(sz)*6`` system clocks to be computed after all the
+    inputs have been clocked in. That is, an FFT of size 1024 would take about
+    ``log2(1024)*6 == 60`` system clocks per sample, for a maximum throughput around
+    1Msample/sec if we had a 60MHz master clock (in reality a bit less accounting for
+    the input and output clocking times).
+
+    This core instantiates 3 memories, which all scale with ``sz``. A ROM for the
+    twiddle factor (coefficient) memory, and 2 RAMs which are shared for input
+    and output sample storage as well as intermediate calculations. An interesting
+    addition to this core in the future may be to support external memory for huge
+    FFT sizes.
+
+    Internals
+    ^^^^^^^^^
+
+    .. note::
+
+        Reading this is not necessary to use the core. I advise reading up a bit on how
+        FFT algorithms work before diving deeper into this. It's just a few notes to anyone
+        interested in understanding this core more deeply.
+
+    This core has 3 main 'phases' in its overall state machine - an input phase (``LOAD1`` and
+    ``LOAD2``), calculation/loop phases (``FFTLOOP`` to ``WRITE-D``) and an output phase
+    (``READ-OUTPUT``).
+
+    The loop phase has an inner counter ``idx``, for the index of the current sample compared
+    to the total block size, and an outer counter ``stage`` which goes from 0 to ``log2(sz)``.
+    Once ``stage`` reaches ``log2(sz)``, the calculations are complete. The input and output
+    phases are simpler to understand, so we'll focus on this loop phase.
+
+    On every loop iteration, we read all needed values from memory and calculate the butterfly
+    sum/difference outputs. Muxes are shown to represent the A / B ping-ponging between
+    which memory they fetch from in even and odd stages (Stage 0 ``X->A, Y->B``, Stage 1
+    ``X->B, Y->A`` and so on up to Stage ``log2(sz)``).
+
+    .. code-block:: text
+
+        ┌─────────┐     ┌─────────┐     ┌─────────┐
+        │  X RAM  │-\\ /-│  Y RAM  │     │  W ROM  │
+        └────┬────┘  X  └────┬────┘     └────┬────┘
+             ▼      / \\      ▼               │
+            MUX<────   ────>MUX              │
+             │               │               │
+             A               B               │
+             │               │               │
+             │         ┌─────┴─────┐         │
+             └────────>┤ Butterfly ├<────────┘
+                       │  S=A+B×W  │
+                       │  D=A-B×W  │
+                       └─────┬─────┘
+                             │S,D
+
+    Once the calculation is complete, the S, D values are written back in a similar ping-pong
+    way to either the X or Y RAMs, depending on which 'stage' we are in. There are 6 states
+    inside the FFT loop required for each iteration of this calculation. Some of them do
+    arithmetic and memory accesses in the same state - in general the timing of each state is
+    optimized to hit around 80MHz on a slowest speed-grade ECP5.
+
+    Members
+    -------
+    i : :py:`In(stream.Signature(Block(CQ(self.shape))))`
+        Incoming stream of blocks of complex samples.
+    o : :py:`Out(stream.Signature(Block(CQ(self.shape))))`
+        Outgoing stream of blocks of complex samples.
+    ifft : :py:`In(1, init=default_ifft)`
+        ``0`` for forward FFT with ``1/N`` normalization. ``1`` for inverse FFT.
+        May only be changed when the core is idle ('ready' and not midway through
+        a block!).
+    """
+
+    def __init__(self,
+                 shape:        fixed.SQ=fixed.SQ(1, 15),
+                 sz:           int=1024,
+                 default_ifft: bool=False) -> None:
+        """
+        shape : fixed.SQ
+            Shape of the fixed-point types used for inputs and outputs. This is
+            the shape of a single number, this core wraps it in :class:`Block`\\(:class:`CQ`\\(shape)).
+        sz : int
+            Size of the FFT/IFFT blocks. Must be a power of 2.
+        default_ifft : bool
+            Default state of the ``self.ifft`` signal, can be used to create an IFFT
+            instead of an FFT by default, without needing to explicitly connect the signal.
+        """
+        self.sz   = sz
+        self.shape = shape
+        super().__init__({
+            "ifft": In(1, init=1 if default_ifft else 0),
+            "i": In(stream.Signature(Block(CQ(self.shape)))),
+            "o": Out(stream.Signature(Block(CQ(self.shape)))),
+        })
+
+    def elaborate(self, platform) -> Module:
+        m = Module()
+
+        # number of stages in FFT
+        n_stages = exact_log2(self.sz)
+        # butterfly / accumulator shape
+        bshape = fixed.SQ(self.shape.i_bits + n_stages, self.shape.f_bits)
+        # twiddle factor / window shape
+        wshape = fixed.SQ(self.shape.i_bits+1, self.shape.f_bits)
+
+        # Complex ping-pong RAM for FFT stages (input, processing and output)
+        m.submodules.x = x = memory.Memory(shape=CQ(bshape), depth=self.sz, init=[])
+        m.submodules.y = y = memory.Memory(shape=CQ(bshape), depth=self.sz, init=[])
+        x_rd = x.read_port()
+        x_wr = x.write_port()
+        y_rd = y.read_port()
+        y_wr = y.write_port()
+
+        # complex ROM for FFT twiddle factors
+        twiddle = [
+            {'real': cos(k*2*pi/self.sz),
+             'imag': sin(k*2*pi/self.sz)}
+            for k in range(self.sz)
+        ]
+        m.submodules.W = W = memory.Memory(
+                shape=CQ(wshape), depth=self.sz, init=twiddle)
+        W_rd = W.read_port()
+
+        # FFT addressing
+        idx = Signal(n_stages+1)
+        revidx = Signal(n_stages)
+        stage = Signal(range(n_stages+1))
+        m.d.comb += revidx.eq(Cat([idx.bit_select(i,1) for i in reversed(range(n_stages))]))
+
+        # Twiddle factor addressing
+        widx = Signal(n_stages)
+        mask = Signal(signed(n_stages))
+        m.d.comb += [
+            widx.eq(idx & mask),
+            W_rd.addr.eq(widx),
+        ]
+
+        # Complex multiplication by twiddle factors requires 4
+        # multiplies. Instead we supply 2 multipliers wired up
+        # to the current twiddle factor real/imag components, so a mux
+        # is only needed on one side of the DSP tile inputs.
+        bw = Signal(CQ(bshape))
+        W_rd_l = Signal(CQ(wshape))
+        mW_rd_r_a = Signal(bshape)
+        mW_rd_r_z = Signal(bshape)
+        m.d.comb += mW_rd_r_z.eq(mW_rd_r_a * W_rd_l.real)
+        mW_rd_i_a = Signal(bshape)
+        mW_rd_i_z = Signal(bshape)
+        m.d.comb += mW_rd_i_z.eq(mW_rd_i_a * W_rd_l.imag)
+
+        # Butterfly sum and difference calculation based on
+        # result of twiddle factor multiplication.
+        a = Signal(CQ(bshape))
+        b = Signal(CQ(bshape))
+        s = Signal(CQ(bshape))
+        d = Signal(CQ(bshape))
+        m.d.comb += [
+            s.real.eq(a.real + bw.real),
+            s.imag.eq(a.imag + bw.imag),
+            d.real.eq(a.real - bw.real),
+            d.imag.eq(a.imag - bw.imag),
+        ]
+
+        # Output and normalization based on ifft / n_stages
+        if n_stages & 1:
+            m.d.comb += self.o.payload.sample.real.eq(y_rd.data.real>>Mux(self.ifft, 0, n_stages))
+            m.d.comb += self.o.payload.sample.imag.eq(y_rd.data.imag>>Mux(self.ifft, 0, n_stages))
+        else:
+            m.d.comb += self.o.payload.sample.real.eq(x_rd.data.real>>Mux(self.ifft, 0, n_stages))
+            m.d.comb += self.o.payload.sample.imag.eq(x_rd.data.imag>>Mux(self.ifft, 0, n_stages))
+
+        # Default RAM addressing and write enable
+        m.d.comb += [
+            y_rd.addr.eq(idx),
+            x_rd.addr.eq(idx),
+        ]
+        m.d.sync += [
+            x_wr.en.eq(0),
+            y_wr.en.eq(0),
+        ]
+
+        with m.FSM():
+            with m.State("RESET"):
+                m.d.sync += idx.eq(0)
+                m.d.sync += self.o.payload.first.eq(1)
+                m.next = "LOAD1"
+
+            with m.State("LOAD1"):
+                with m.If(idx >= self.sz):
+                    m.d.sync += [
+                        stage.eq(0),
+                        idx.eq(0),
+                        mask.eq(~((2 << (n_stages-2))-1)),
+                    ]
+                    m.next = "FFTLOOP"
+                with m.Else():
+                    m.next = "LOAD2"
+
+            with m.State("LOAD2"):
+                m.d.comb += self.i.ready.eq(1)
+                with m.If(self.i.valid & ((idx > 0) | self.i.payload.first)):
+                    m.d.sync += [
+                        x_wr.data.real.eq(self.i.payload.sample.real),
+                        x_wr.data.imag.eq(self.i.payload.sample.imag),
+                        x_wr.addr.eq(revidx),
+                        x_wr.en.eq(1),
+                        idx.eq(idx+1),
+                    ]
+                    m.next = "LOAD1"
+
+            with m.State("FFTLOOP"):
+                with m.If(idx >= self.sz):
+                    # This stage is complete. Move to next stage.
+                    m.d.sync += [
+                        idx.eq(0),
+                        mask.eq(mask>>1),
+                        stage.eq(stage+1),
+                    ]
+                with m.If(stage >= n_stages):
+                    # FFT calculation is complete. Output result.
+                    m.d.sync += idx.eq(0)
+                    m.next = "OUTPUT"
+                with m.Else():
+                    # This stage requires more processing. Set up
+                    # a read for 'B' from RAM.
+                    m.d.comb += y_rd.addr.eq(2*idx+1)
+                    m.d.comb += x_rd.addr.eq(2*idx+1)
+                    m.next = "READB"
+
+            with m.State("READB"):
+                # Read out 'B' from RAM, latch it to the complex multiplier
+                # inputs, and simultaneously set up a read for 'A' from RAM.
+                m.d.comb += y_rd.addr.eq(2*idx)
+                m.d.comb += x_rd.addr.eq(2*idx)
+                with m.If(stage & 1):
+                    m.d.sync += [
+                        b.real.eq(y_rd.data.real),
+                        b.imag.eq(y_rd.data.imag),
+                        mW_rd_r_a.eq(y_rd.data.real),
+                        mW_rd_i_a.eq(y_rd.data.real),
+                    ]
+                with m.Else():
+                    m.d.sync += [
+                        b.real.eq(x_rd.data.real),
+                        b.imag.eq(x_rd.data.imag),
+                        mW_rd_r_a.eq(x_rd.data.real),
+                        mW_rd_i_a.eq(x_rd.data.real),
+                    ]
+                # Latch current twiddle factors from memory to cut timing.
+                with m.If(self.ifft):
+                    # conjugate twiddle factors on inverse fft.
+                    m.d.sync += W_rd_l.real.eq(W_rd.data.real)
+                    m.d.sync += W_rd_l.imag.eq(W_rd.data.imag)
+                with m.Else():
+                    m.d.sync += W_rd_l.real.eq(W_rd.data.real)
+                    m.d.sync += W_rd_l.imag.eq(-W_rd.data.imag)
+                m.next = "READA-BUTTERFLY0"
+
+            with m.State("READA-BUTTERFLY0"):
+                # Read out 'A' from RAM, latch it to the butterfly inputs.
+                with m.If(stage & 1):
+                    m.d.sync += [
+                        a.real.eq(y_rd.data.real),
+                        a.imag.eq(y_rd.data.imag),
+                    ]
+                with m.Else():
+                    m.d.sync += [
+                        a.real.eq(x_rd.data.real),
+                        a.imag.eq(x_rd.data.imag),
+                    ]
+                # Latch first 2 multiplies into 'bw' and set up the next 2
+                # multiplies (4 needed for the overall complex multiply).
+                m.d.sync += mW_rd_i_a.eq(b.imag)
+                m.d.sync += mW_rd_r_a.eq(b.imag)
+                m.d.sync += bw.real.eq(mW_rd_r_z)
+                m.d.sync += bw.imag.eq(mW_rd_i_z)
+                m.next = "BUTTERFLY1"
+
+            with m.State("BUTTERFLY1"):
+                # Accumulate second 2 multiplies into 'bw'.
+                m.d.sync += bw.real.eq(bw.real - mW_rd_i_z)
+                m.d.sync += bw.imag.eq(bw.imag + mW_rd_r_z)
+                m.next = "WRITE-S"
+
+            with m.State("WRITE-S"):
+                # Set up a write to RAM of the butterfly sum term.
+                with m.If(stage & 1):
+                    m.d.sync += [
+                        x_wr.en.eq(1),
+                        x_wr.data.real.eq(s.real),
+                        x_wr.data.imag.eq(s.imag),
+                        x_wr.addr.eq(idx),
+                    ]
+                with m.Else():
+                    m.d.sync += [
+                        y_wr.en.eq(1),
+                        y_wr.data.real.eq(s.real),
+                        y_wr.data.imag.eq(s.imag),
+                        y_wr.addr.eq(idx),
+                    ]
+                m.next = "WRITE-D"
+
+            with m.State("WRITE-D"):
+                # Set up a write to RAM of the butterfly diff term.
+                with m.If(stage & 1):
+                    m.d.sync += [
+                        x_wr.en.eq(1),
+                        x_wr.data.real.eq(d.real),
+                        x_wr.data.imag.eq(d.imag),
+                        x_wr.addr.eq(idx+(self.sz>>1)),
+                    ]
+                with m.Else():
+                    m.d.sync += [
+                        y_wr.en.eq(1),
+                        y_wr.data.real.eq(d.real),
+                        y_wr.data.imag.eq(d.imag),
+                        y_wr.addr.eq(idx+(self.sz>>1)),
+                    ]
+                m.d.sync += idx.eq(idx+1)
+                m.next = "FFTLOOP"
+
+            with m.State("OUTPUT"):
+                with m.If(idx >= self.sz):
+                    m.next = "RESET"
+                with m.Else():
+                    m.next = "READOUT"
+
+            with m.State("READOUT"):
+                m.d.comb += self.o.valid.eq(1)
+                with m.If(self.o.ready):
+                    m.d.sync += [
+                        idx.eq(idx+1),
+                        self.o.payload.first.eq(0),
+                    ]
+                    m.next = "OUTPUT"
+
+        return m
+
+class Window(wiring.Component):
+
+    """Pointwise window function.
+
+    Apply a real window function of size ``sz`` to blocks of ``shape``.
+    The window function is synchronized to the block ``payload.first``.
+
+    Design
+    ------
+
+    This core is iterative and uses a single multiplier. It does not
+    store any samples, the windowed samples are available at the output
+    2 clocks after they are provided at the input.
+
+    Members
+    -------
+    i : :py:`In(stream.Signature(Block(self.shape)))`
+        Incoming stream of blocks of real samples.
+        at intervals matching the ``sz`` of this component.
+    o : :py:`Out(stream.Signature(Block(self.shape)))`
+        Outgoing stream of blocks of real samples.
+        at intervals matching the ``sz`` of this component.
+    """
+
+    class Function(Enum):
+        """Enumeration representing different window functions for :class:`Window`."""
+        #:
+        HANN      = lambda k, sz: 0.5 - 0.5*cos(k*2*pi/sz)
+        #:
+        SQRT_HANN = lambda k, sz: sqrt(0.5 - 0.5*cos(k*2*pi/sz))
+        #:
+        RECT      = lambda k, sz: 1.
+
+    def __init__(self,
+                 shape: fixed.SQ,
+                 sz:    int,
+                 # Default: sqrt(Hann) window for STFT
+                 window_function = Function.SQRT_HANN) -> None:
+
+        """
+        shape : fixed.SQ
+            Shape of the fixed-point types used for inputs and outputs. This is
+            the shape of a single number, this core wraps it in :class:`Block`\\(shape).
+        sz : int
+            Size of the window function.
+        window_function : Function
+            Function used to calculate window function constants (type of window).
+        """
+        self.sz   = sz
+        self.shape = shape
+        self.window_function = window_function
+        super().__init__({
+            "i": In(stream.Signature(Block(self.shape))),
+            "o": Out(stream.Signature(Block(self.shape))),
+        })
+
+    def elaborate(self, platform) -> Module:
+        m = Module()
+
+        wFr = [self.window_function(k, self.sz) for k in range(self.sz)]
+
+        wshape = fixed.SQ(self.shape.i_bits+1, self.shape.f_bits)
+        m.submodules.wFr = wFr = memory.Memory(
+                shape=wshape, depth=self.sz, init=wFr)
+
+        wFr_rd = wFr.read_port()
+
+        i_latch = Signal.like(self.i.payload.sample)
+        wfidx = Signal(range(self.sz+1))
+        m.d.comb += wFr_rd.addr.eq(wfidx)
+        with m.FSM():
+            with m.State("RESET"):
+                m.d.sync += wfidx.eq(0)
+                m.d.comb += self.i.ready.eq(1)
+                with m.If(self.i.valid & self.i.payload.first):
+                    m.d.sync += i_latch.eq(self.i.payload.sample)
+                    m.d.sync += self.o.payload.first.eq(1)
+                    m.next = "WINDOW"
+            with m.State("NEXT"):
+                m.d.comb += self.i.ready.eq(1)
+                m.d.sync += self.o.payload.first.eq(0)
+                with m.If(self.i.valid):
+                    m.d.sync += i_latch.eq(self.i.payload.sample)
+                    m.next = "WINDOW"
+            with m.State("WINDOW"):
+                m.d.sync += self.o.payload.sample.eq(wFr_rd.data*i_latch),
+                m.next = "OUT"
+            with m.State("OUT"):
+                m.d.comb += self.o.valid.eq(1)
+                with m.If(self.o.ready):
+                    with m.If(wfidx != (self.sz - 1)):
+                        m.d.sync += wfidx.eq(wfidx+1)
+                        m.next = "NEXT"
+                    with m.Else():
+                        m.next = "RESET"
+        return m
+
+
+class ComputeOverlappingBlocks(wiring.Component):
+
+    """Real sample stream to (overlapping) :class:`Block` stream conversion.
+
+    This core is a building block for the :class:`STFTProcessor` family of components. It takes
+    a continuous (non-delineated) stream of samples, and sends delineated blocks
+    of samples, which may be overlapping, for use by further processing.
+
+    Here is a quick example to illustrate. From the input perspective, each sample
+    would correspond to the following output samples (taking sz=8, n_overlap=4):
+
+    .. code-block:: text
+
+        Input:    0 1 2 3 4 5 6 7 8 9 A B C D E F ...
+        Block 1:  0 1 2 3 4 5 6 7
+        Block 2:          4 5 6 7 8 9 A B
+        Block 3:                  8 9 A B C D E F
+
+    Looking at this from the output perspective:
+
+    .. code-block:: text
+
+        payload.sample:  0 1 2 3 4 5 6 7 4 5 6 7 8 9 A B 8 9 A B C D E F
+        payload.first:   1               1               1
+
+    To avoid backpressure on the input stream, the incoming sample rate should be much
+    slower than the system clock, and rate of processing the output blocks (which is easily
+    achievable with audio signals).
+
+    Design
+    ------
+
+    This core uses a single ``SyncFIFO`` for storage of size ``n_overlap``, which is
+    continuously filled and drained between blocks to create overlapping outputs.
+
+    Members
+    -------
+    i : :py:`In(stream.Signature(self.shape))`
+        Incoming (continuous) stream of real samples.
+    o : :py:`Out(stream.Signature(Block(self.shape)))`
+        Outgoing stream of blocks of real samples.
+        at intervals matching the ``sz`` of this component.
+    """
+
+    def __init__(self,
+                 shape:     fixed.SQ,
+                 sz:        int,
+                 n_overlap: int):
+        """
+        shape : fixed.SQ
+            Shape of the fixed-point types used for inputs and outputs. This is
+            the shape of a single number, this core wraps it in :class:`Block`\\(shape).
+        sz : int
+            Size of the output blocks.
+        n_overlap : int
+            Number of elements shared between adjacent output blocks.
+        """
+
+        # TODO: currently, only even overlap is tested, as required by STFT.
+        assert n_overlap == (sz // 2)
+
+        self.sz        = sz
+        self.shape     = shape
+        self.n_overlap = n_overlap
+
+        super().__init__({
+            "i": In(stream.Signature(self.shape)),
+            "o": Out(stream.Signature(Block(self.shape))),
+        })
+
+    def elaborate(self, platform) -> Module:
+        m = Module()
+
+        m.submodules.overlap_fifo = overlap_fifo = fifo.SyncFIFOBuffered(
+            width=self.shape.as_shape().width, depth=self.n_overlap)
+
+        n_samples = Signal(range(self.sz), init=0)
+        with m.If(self.i.valid & self.i.ready):
+            m.d.sync += n_samples.eq(n_samples+1)
+
+        m.d.comb += [
+            self.o.payload.sample.eq(self.i.payload),
+            self.o.payload.first.eq(
+                overlap_fifo.r_level == self.n_overlap),
+            overlap_fifo.w_data.eq(self.i.payload),
+            self.o.valid.eq(self.i.valid),
+            self.i.ready.eq(self.o.ready),
+        ]
+
+        with m.FSM():
+            with m.State("START"):
+                m.d.comb += self.o.payload.first.eq(1)
+                with m.If(n_samples == (self.sz - self.n_overlap)):
+                    m.next = "FILL"
+            with m.State("FILL"):
+                with m.If(overlap_fifo.r_level == self.n_overlap):
+                    m.d.comb += [
+                        self.i.ready.eq(0),
+                        self.o.valid.eq(0),
+                    ]
+                    m.next = "DRAIN"
+                with m.Else():
+                    m.d.comb += overlap_fifo.w_en.eq(self.i.valid & self.i.ready)
+            with m.State("DRAIN"):
+                with m.If(overlap_fifo.r_level != 0):
+                    m.d.comb += [
+                        self.i.ready.eq(0),
+                        self.o.valid.eq(1),
+                        self.o.payload.sample.eq(overlap_fifo.r_data),
+                        overlap_fifo.r_en.eq(self.o.ready),
+                    ]
+                with m.Else():
+                    m.next = "FILL"
+
+        return m
+
+class OverlapAddBlocks(wiring.Component):
+    """Convert :class:`Block` stream to continuous samples by 'Overlap-Add'.
+
+    This core is a building block for the :class:`STFTProcessor` family of components. It takes
+    overlapping, delineated blocks of samples, adds up the overlapping elements
+    and sends a stream of (non-delineated) continuous samples.
+
+    Again, an example for (sz=8, n_overlap=4). From the input perspective, say we have:
+
+    .. code-block:: text
+
+        payload.sample:  0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J ...
+        payload.first:   1               1               1
+
+    This core would send out the following stream:
+
+    .. code-block:: text
+
+        Block 1:  0 1 2 3 4 5 6 7
+        Block 2:          8 9 A B C D E F
+        Block 3:                  G H I J ...
+
+        Out:      0 1 2 3 4 5 6 7 C D E J
+                  + + + + + + + + + + + +
+                  X X X X 8 9 A B G H I F ... (X == zero padding)
+
+    From above, it should be clear that each output sample is formed by summing the
+    'overlapping' parts of each input block, and that there are less output samples
+    than input samples as a result.
+
+    Note that connecting a :class:`ComputeOverlappingBlocks` straight to an :class:`OverlapAddBlocks`
+    will not reconstruct the original signal, unless the samples are windowed (tapered)
+    for perfect reconstruction. For an example, see the :class:`STFTProcessor` family of components.
+
+    Design
+    ------
+
+    This core uses two ``SyncFIFO`` for storage of size ``sz``, which are both
+    continuously filled and drained as necessary to add up the correct overlapping parts.
+
+    Members
+    -------
+    i : :py:`In(stream.Signature(Block(self.shape)))`
+        Incoming stream of blocks of overlapping real samples.
+    o : :py:`Out(stream.Signature(self.shape))`
+        Outgoing stream of continuous real samples.
+    """
+
+    def __init__(self,
+                 shape:     fixed.SQ,
+                 sz:        int,
+                 n_overlap: int):
+        """
+        shape : fixed.SQ
+            Shape of the fixed-point types used for inputs and outputs. This is
+            the shape of a single number, this core wraps it in :class:`Block`\\(shape).
+        sz : int
+            Size of the input blocks.
+        n_overlap : int
+            Number of elements shared between adjacent input blocks.
+        """
+
+        self.sz        = sz
+        self.shape     = shape
+        self.n_overlap = n_overlap
+
+        super().__init__({
+            "i": In(stream.Signature(Block(self.shape))),
+            "o": Out(stream.Signature(self.shape))
+        })
+
+    def elaborate(self, platform) -> Module:
+        m = Module()
+
+        m.submodules.fifo1 = fifo1 = fifo.SyncFIFOBuffered(
+            width=self.shape.as_shape().width, depth=self.sz)
+        m.submodules.fifo2 = fifo2 = fifo.SyncFIFOBuffered(
+            width=self.shape.as_shape().width, depth=self.sz)
+
+        swap_fifos = Signal()
+        m.d.comb += [
+            swap_fifos.eq(
+                self.i.valid & self.i.ready & self.i.payload.first),
+            fifo1.w_data.eq(self.i.payload.sample),
+            fifo2.w_data.eq(self.i.payload.sample),
+        ]
+
+        with m.FSM():
+            with m.State("PRE-FILL"):
+                with m.If(fifo2.w_level != self.n_overlap):
+                    m.d.comb += [
+                        fifo2.w_en.eq(1),
+                        fifo2.w_data.eq(0),
+                    ]
+                with m.Else():
+                    m.d.comb += self.i.ready.eq(1)
+                    with m.If(swap_fifos):
+                        m.d.comb += fifo1.w_en.eq(1)
+                        m.next = "FIFO1"
+            with m.State("FIFO1"):
+                m.d.comb += [
+                    self.i.ready.eq(fifo1.w_rdy),
+                    fifo1.w_en.eq(self.i.valid & ~self.i.payload.first),
+                ]
+                with m.If(swap_fifos):
+                    m.d.comb += fifo2.w_en.eq(1)
+                    m.next = "FIFO2"
+            with m.State("FIFO2"):
+                m.d.comb += [
+                    self.i.ready.eq(fifo2.w_rdy),
+                    fifo2.w_en.eq(self.i.valid & ~self.i.payload.first),
+                ]
+                with m.If(swap_fifos):
+                    m.d.comb += fifo1.w_en.eq(1)
+                    m.next = "FIFO1"
+
+        out_a = Signal(self.shape)
+        out_b = Signal(self.shape)
+        m.d.comb += [
+            self.o.valid.eq(fifo1.r_rdy & fifo2.r_rdy),
+            out_a.eq(fifo1.r_data),
+            out_b.eq(fifo2.r_data),
+            self.o.payload.eq(out_a + out_b),
+            fifo1.r_en.eq(self.o.valid & self.o.ready),
+            fifo2.r_en.eq(self.o.valid & self.o.ready),
+        ]
+
+        return m
+
+class STFTProcessor(wiring.Component):
+
+    """Short-Time Fourier Transform ('Overlap-Add') with shared FFT core.
+
+    This core performs both analysis and re-synthesis of time-domain samples by passing
+    them through the frequency domain for spectral processing by user logic.
+
+    The general flow of operations:
+
+        - ``i`` (samples in) -> :class:`ComputeOverlappingBlocks` -> :class:`Window` -> :class:`FFT` -> ``o_freq``
+        - ``i_freq`` -> :class:`FFT` (inverse) -> :class:`Window` -> :class:`OverlapAddBlocks` -> ``o`` (samples out)
+
+    If ``o_freq`` and ``i_freq`` frequency-domain streams are directly connected together
+    with no processing logic, this core will perfectly resynthesize the original signal.
+
+    :class:`Window.Function.SQRT_HANN` windowing is used in both the analysis and synthesis stages.
+
+    Design
+    ------
+
+    Unlike :class:`STFTProcessorPipelined`, this implementation saves area by time-multiplexing
+    :class:`FFT` and :class:`Window` cores between analysis and synthesis operations, at the cost of
+    reduced throughput. For audio purposes, this core is easily still fast enough for real-time
+    processing.
+
+    At a high level, the components are connected in a different sequence depending
+    on which state the core is in. The core contains a single `SyncFIFO` used to buffer
+    all the outputs of user (frequency domain) processing logic. This is required to
+    avoid backpressure on the user logic while it is disconnected from the IFFT stage.
+
+    Members
+    -------
+    i : :py:`In(stream.Signature(shape))`
+        Continuous time-domain input stream
+    o : :py:`Out(stream.Signature(shape))`
+        Continuous time-domain output stream (reconstructed)
+    o_freq : :py:`Out(stream.Signature(Block(CQ(shape))))`
+        Frequency-domain output blocks for processing by user logic
+    i_freq : :py:`In(stream.Signature(Block(CQ(shape))))`
+        Frequency-domain input blocks after processing by user logic
+    """
+
+    def __init__(self,
+                 shape: fixed.SQ,
+                 sz:    int):
+        """
+        shape : fixed.SQ
+            Shape of the fixed-point samples used for inputs and outputs.
+        sz : int
+            Size of the frequency-domain blocks used internally and exposed for frequency
+            domain processing. ``o_freq`` and ``i_freq`` are delineated by blocks
+            with a ``payload.first`` strobe every ``sz`` elements.
+        """
+
+        self.sz        = sz
+        self.shape     = shape
+
+        self.overlap_blocks = ComputeOverlappingBlocks(sz=sz, shape=shape, n_overlap=sz//2)
+        self.window         = Window(sz=sz, shape=shape, window_function=Window.Function.SQRT_HANN)
+        self.fft            = FFT(sz=sz, shape=shape)
+        self.overlap_add    = OverlapAddBlocks(sz=sz, shape=shape, n_overlap=sz//2)
+
+        super().__init__({
+            # Time domain input and resynthesized output
+            "i": In(stream.Signature(self.shape)),
+            "o": Out(stream.Signature(self.shape)),
+            # Frequency domain analysis and resynthesis blocks, to be hooked
+            # up to user frequency-domain block processing logic. If `o_freq`
+            # is connected straight to `i_freq` the output will simply
+            # resynthesize the input unmodified.
+            "o_freq": Out(stream.Signature(Block(CQ(self.shape)))),
+            "i_freq": In(stream.Signature(Block(CQ(self.shape)))),
+        })
+
+    def elaborate(self, platform) -> Module:
+        m = Module()
+
+        m.submodules.overlap_blocks   = self.overlap_blocks
+        m.submodules.window           = self.window
+        m.submodules.fft              = self.fft
+        m.submodules.overlap_add      = self.overlap_add
+
+        m.submodules.pfifo = pfifo = fifo.SyncFIFOBuffered(
+            width=self.i_freq.payload.shape().size, depth=self.sz)
+
+        wiring.connect(m, wiring.flipped(self.i), self.overlap_blocks.i)
+        wiring.connect(m, self.overlap_add.o, wiring.flipped(self.o))
+
+        n_samples = Signal(range(self.sz+1), init=0)
+
+        with m.FSM():
+            with m.State("LOAD"):
+                m.d.comb += self.fft.ifft.eq(0)
+                wiring.connect(m, self.overlap_blocks.o, self.window.i)
+                connect_sq_to_real(m, self.window.o, self.fft.i)
+                with m.If(self.overlap_blocks.o.valid & self.overlap_blocks.o.ready):
+                    m.d.sync += n_samples.eq(n_samples+1)
+                with m.If(n_samples == self.sz):
+                    m.next = "ANALYZE"
+            with m.State("ANALYZE"):
+                connect_sq_to_real(m, self.window.o, self.fft.i)
+                wiring.connect(m, self.fft.o, wiring.flipped(self.o_freq))
+                wiring.connect(m, wiring.flipped(self.i_freq), pfifo.w_stream)
+                with m.If(pfifo.w_level == self.sz):
+                    m.next = "SYNTHESIZE"
+            with m.State("SYNTHESIZE"):
+                m.d.comb += self.fft.ifft.eq(1)
+                wiring.connect(m, pfifo.r_stream, self.fft.i)
+                connect_real_to_sq(m, self.fft.o, self.window.i)
+                wiring.connect(m, self.window.o, self.overlap_add.i)
+                with m.If(self.window.o.valid & self.window.o.ready):
+                    m.d.sync += n_samples.eq(n_samples-1)
+                with m.If(n_samples == 0):
+                    m.next = "LOAD"
+
+        return m
+
+class STFTAnalyzer(wiring.Component):
+
+    """Short-Time Fourier Transform for spectral analysis.
+
+    This core allows frequency-domain analysis of time-domain samples by passing them through
+    the following signal flow:
+
+        - ``i`` (samples in) -> :class:`ComputeOverlappingBlocks` -> :class:`Window` -> :class:`FFT` -> ``o``
+
+    For a more resource-efficient STFT that performs both analysis and synthesis, see :class:`STFTProcessor`.
+
+    Members
+    -------
+    i : :py:`In(stream.Signature(shape))`
+        Continuous time-domain input stream
+    o : :py:`Out(stream.Signature(Block(CQ(shape))))`
+        Frequency-domain output blocks for processing by user logic
+    """
+
+    def __init__(self,
+                 shape: fixed.SQ,
+                 sz:    int,
+                 window_function = Window.Function.HANN):
+        """
+        shape : fixed.SQ
+            Shape of the fixed-point samples used for inputs and outputs.
+        sz : int
+            Size of the frequency-domain blocks used internally and exposed for frequency
+            domain processing.
+        window : Window.Function
+            Window function applied to time-domain blocks the FFT.
+        """
+
+        self.sz        = sz
+        self.shape     = shape
+
+        self.overlap_blocks   = ComputeOverlappingBlocks(sz=sz, shape=shape, n_overlap=sz//2)
+        self.window_analysis  = Window(sz=sz, shape=shape, window_function=window_function)
+        self.fft              = FFT(sz=sz, shape=shape)
+
+        super().__init__({
+            "i": In(stream.Signature(self.shape)),
+            "o": Out(stream.Signature(Block(CQ(self.shape)))),
+        })
+
+    def elaborate(self, platform) -> Module:
+        m = Module()
+
+        m.submodules.overlap_blocks   = self.overlap_blocks
+        m.submodules.window_analysis  = self.window_analysis
+        m.submodules.fft              = self.fft
+
+        # Continuous time-domain input -> windowed overlapping frequency domain blocks
+        wiring.connect(m, wiring.flipped(self.i), self.overlap_blocks.i)
+        wiring.connect(m, self.overlap_blocks.o, self.window_analysis.i)
+        connect_sq_to_real(m, self.window_analysis.o, self.fft.i)
+        wiring.connect(m, self.fft.o, wiring.flipped(self.o))
+
+        return m
+
+class STFTSynthesizer(wiring.Component):
+
+    """Short-Time Fourier Transform for spectral synthesis.
+
+    This core allows frequency-domain synthesis of time-domain samples by passing them through
+    the following signal flow:
+
+        - ``i_freq`` -> :class:`FFT` (inverse) -> :class:`Window` -> :class:`OverlapAddBlocks` -> ``o`` (samples out)
+
+    For a more resource-efficient STFT that performs both analysis and synthesis, see :class:`STFTProcessor`.
+
+    Members
+    -------
+    i : :py:`In(stream.Signature(Block(CQ(shape))))`
+        Frequency-domain input blocks used for synthesis.
+    o : :py:`Out(stream.Signature(shape))`
+        Continuous time-domain output stream
+    """
+
+    def __init__(self,
+                 shape: fixed.SQ,
+                 sz:    int,
+                 window_function = Window.Function.HANN):
+        """
+        shape : fixed.SQ
+            Shape of the fixed-point samples used for inputs and outputs.
+        sz : int
+            Size of the frequency-domain blocks used internally and exposed for frequency
+            domain processing.
+        window : Window.Function
+            Window function applied to time-domain blocks after the IFFT, but before overlap-add.
+        """
+
+        self.sz        = sz
+        self.shape     = shape
+
+        self.ifft             = FFT(sz=sz, shape=shape, default_ifft=True)
+        self.window_synthesis = Window(sz=sz, shape=shape, window_function=window_function)
+        self.overlap_add      = OverlapAddBlocks(sz=sz, shape=shape, n_overlap=sz//2)
+
+        super().__init__({
+            "i": In(stream.Signature(Block(CQ(self.shape)))),
+            "o": Out(stream.Signature(self.shape)),
+        })
+
+    def elaborate(self, platform) -> Module:
+        m = Module()
+
+        m.submodules.ifft             = self.ifft
+        m.submodules.window_synthesis = self.window_synthesis
+        m.submodules.overlap_add      = self.overlap_add
+
+        # Processed frequency-domain blocks -> continuous time-domain output (using overlap-add)
+        wiring.connect(m, wiring.flipped(self.i), self.ifft.i)
+        connect_real_to_sq(m, self.ifft.o, self.window_synthesis.i)
+        wiring.connect(m, self.window_synthesis.o, self.overlap_add.i)
+        wiring.connect(m, self.overlap_add.o, wiring.flipped(self.o))
+
+        return m
+
+class STFTProcessorPipelined(wiring.Component):
+
+    """Short-Time Fourier Transform ('Overlap-Add') with separate FFT/IFFT cores.
+
+    This core performs both analysis and re-synthesis of time-domain samples by passing
+    them through the frequency domain for spectral processing by user logic.
+
+    This is a simpler-to-understand version of :class:`STFTProcessor` as it does not share
+    the :class:`Window` or :class:`FFT` cores, making it higher throughput, but also higher
+    resource usage, because it can perform the FFT and IFFT at the same time.
+
+    This core is mostly used for testing the :class:`STFTAnalyzer` and :class:`STFTSynthesizer`
+    components in isolation, and doesn't make much sense to use in real projects compared
+    to just using the :class:`STFTProcessor` above, which is much more resource efficient
+    for audio applications. Unless you have super high sample rates.
+
+    Members
+    -------
+    i : :py:`In(stream.Signature(shape))`
+        Continuous time-domain input stream
+    o : :py:`Out(stream.Signature(shape))`
+        Continuous time-domain output stream (reconstructed)
+    o_freq : :py:`Out(stream.Signature(Block(CQ(shape))))`
+        Frequency-domain output blocks for processing by user logic
+    i_freq : :py:`In(stream.Signature(Block(CQ(shape))))`
+        Frequency-domain input blocks after processing by user logic
+    """
+
+    def __init__(self,
+                 shape: fixed.SQ,
+                 sz:    int):
+        """
+        shape : fixed.SQ
+            Shape of the fixed-point samples used for inputs and outputs.
+        sz : int
+            Size of the frequency-domain blocks used internally and exposed for frequency
+            domain processing.
+        """
+
+        self.sz        = sz
+        self.shape     = shape
+
+        # Symmetric sqrt(Hann) windows for resynthesis.
+        self.analyzer    = STFTAnalyzer(shape=shape, sz=sz, window_function=Window.Function.SQRT_HANN)
+        self.synthesizer = STFTSynthesizer(shape=shape, sz=sz, window_function=Window.Function.SQRT_HANN)
+
+        super().__init__({
+            # Time domain input and resynthesized output
+            "i": In(stream.Signature(self.shape)),
+            "o": Out(stream.Signature(self.shape)),
+            # Frequency domain analysis and resynthesis blocks, to be hooked
+            # up to user frequency-domain block processing logic. If `o_freq`
+            # is connected straight to `i_freq` the output will simply
+            # resynthesize the input unmodified.
+            "o_freq": Out(stream.Signature(Block(CQ(self.shape)))),
+            "i_freq": In(stream.Signature(Block(CQ(self.shape)))),
+        })
+
+    def elaborate(self, platform) -> Module:
+        m = Module()
+
+        m.submodules.analyzer = self.analyzer
+        m.submodules.synthesizer = self.synthesizer
+
+        wiring.connect(m, wiring.flipped(self.i), self.analyzer.i)
+        wiring.connect(m, self.analyzer.o, wiring.flipped(self.o_freq))
+
+        # Processed frequency-domain blocks -> continuous time-domain output (using overlap-add)
+        wiring.connect(m, wiring.flipped(self.i_freq), self.synthesizer.i)
+        wiring.connect(m, self.synthesizer.o, wiring.flipped(self.o))
+
+        return m

--- a/gateware/src/tiliqua/spectral.py
+++ b/gateware/src/tiliqua/spectral.py
@@ -1,0 +1,300 @@
+# Copyright (c) 2024 S. Holzapfel <me@sebholzapfel.com>
+#
+# SPDX-License-Identifier: CERN-OHL-S-2.0
+#
+
+"""Spectral processing components."""
+
+from amaranth import *
+from amaranth.lib import wiring, data, stream, memory
+from amaranth.lib.wiring import In, Out
+from amaranth.utils import exact_log2
+
+from amaranth_future import fixed
+
+from math import atan, pi
+
+from tiliqua import dsp, mac, cordic
+from tiliqua.complex import CQ, connect_magnitude_to_sq
+from tiliqua.block import Block
+
+class BlockLPF(wiring.Component):
+
+    """Block-based (point-wise) one-pole low-pass filter array.
+
+    This is an array (size `sz`) of one-pole low-pass filters with a single
+    adjustable smoothing constant `beta`. That is, an independent filter is
+    tracked for every element in each block. The :class:`Block` ``payload.first``
+    flags are used to track which filter memory should be addressed for each
+    sample, without requiring separate streams for each channel.
+
+    For each element, we compute:
+
+    .. code-block:: text
+
+        self.y[n] = self.y[n]*self.beta + self.x[n]*(1-self.beta)
+
+    This is useful for morphing between blocks of real spectral envelopes, but could
+    also be used for other purposes.
+
+    Members
+    -------
+    i : :py:`In(stream.Signature(Block(self.shape)))`
+        Incoming stream of blocks of real samples.
+    o : :py:`Out(stream.Signature(Block(self.shape)))`
+        Outgoing stream of blocks of real samples.
+    """
+
+    def __init__(self,
+                 shape: fixed.Shape,
+                 sz: int,
+                 macp = None):
+        """
+        shape : Shape
+            Shape of fixed-point number to use for block streams.
+        sz : int
+            Number of independent filters, must exactly match the size of each block.
+        macp : bool
+            A :class:`mac.MAC` provider, for multiplies.
+        """
+        self.shape = shape
+        self.sz    = sz
+        self.macp = macp or mac.MAC.default()
+        super().__init__({
+            # Low-pass 1-pole smoothing constant, 0 (slow response) to 1 (fast response).
+            "beta": In(self.shape, init=fixed.Const(0.75, shape=self.shape)),
+            # Blockwise sets of signals to filter.
+            "i": In(stream.Signature(Block(self.shape))),
+            "o": Out(stream.Signature(Block(self.shape))),
+        })
+
+    def elaborate(self, platform) -> Module:
+        m = Module()
+
+        m.submodules.macp = mp = self.macp
+
+        #
+        # Filter memory and ports
+        #
+
+        m.submodules.mem = mem = memory.Memory(shape=self.shape, depth=self.sz, init=[])
+        mem_rd = mem.read_port()
+        mem_wr = mem.write_port()
+
+        #
+        # Filter memory addressing
+        #
+
+        idx = Signal(range(self.sz+1))
+        l_in = Signal(self.shape)
+        m.d.comb += [
+            mem_rd.en.eq(1),
+            mem_rd.addr.eq(idx),
+            mem_wr.addr.eq(idx),
+        ]
+        m.d.sync += mem_wr.en.eq(0)
+
+        #
+        # Iterative MAC state machine
+        #
+
+        with m.FSM():
+            with m.State("IDLE"):
+                m.d.comb += self.i.ready.eq(1)
+                with m.If(self.i.valid):
+                    m.d.sync += l_in.eq(self.i.payload.sample)
+                    with m.If(self.i.payload.first):
+                        m.d.sync += idx.eq(0)
+                    with m.Else():
+                        m.d.sync += idx.eq(idx+1)
+                    m.next = "READ"
+
+            with m.State("READ"):
+                m.next = "MAC1"
+
+            with m.State("MAC1"):
+                with mp.Multiply(m, a=mem_rd.data, b=self.beta):
+                    m.d.sync += mem_wr.data.eq(mp.z)
+                    m.next = "MAC2"
+
+            with m.State("MAC2"):
+                with mp.Multiply(m, a=l_in, b=(fixed.Const(1.0, shape=self.shape, clamp=True)-self.beta)):
+                    m.d.sync += mem_wr.data.eq(mem_wr.data + mp.z)
+                    m.next = "UPDATE"
+
+            with m.State("UPDATE"):
+                m.d.sync += [
+                    mem_wr.en.eq(1),
+                    self.o.payload.first.eq(idx == 0),
+                    self.o.payload.sample.eq(mem_wr.data),
+                ]
+                m.next = "OUTPUT"
+
+            with m.State("OUTPUT"):
+                m.d.comb += self.o.valid.eq(1)
+                with m.If(self.o.ready):
+                    m.next = "IDLE"
+
+        return m
+
+class SpectralEnvelope(wiring.Component):
+
+    """Compute a smoothed, real spectral envelope.
+
+    Given a block of complex frequency-domain spectra, extract the
+    magnitude from each point and filter each magnitude in the block
+    independently with a one-pole smoother, emitting a corresponding
+    block representing the evolving (smoothed)  spectral envelope.
+
+    The rect-to-polar CORDIC is run without magnitude correction, which
+    saves another multiplier at the cost of everything being multiplied
+    by a constant factor (may or may not matter depending on the use).
+
+    Members
+    -------
+    i : :py:`In(stream.Signature(Block(CQ(self.shape))))`
+        Incoming stream of blocks of complex spectra.
+    o : :py:`Out(stream.Signature(Block(self.shape)))`
+        Outgoing stream of blocks of real (smoothed) magnitude spectra.
+    """
+
+    def __init__(self,
+                 shape: fixed.Shape,
+                 sz: int):
+        """
+        shape : Shape
+            Shape of fixed-point number to use for streams.
+        sz : int
+            The size of each input block and outgoing spectral envelope blocks.
+        """
+        self.shape = shape
+        self.sz    = sz
+        super().__init__({
+            "i": In(stream.Signature(Block(CQ(self.shape)))),
+            "o": Out(stream.Signature(Block(self.shape))),
+        })
+
+    def elaborate(self, platform) -> Module:
+        m = Module()
+        m.submodules.rect_to_polar = rect_to_polar = cordic.RectToPolarCordic(
+                self.shape, magnitude_correction=False)
+        m.submodules.block_lpf = block_lpf = BlockLPF(
+                self.shape, self.sz)
+        wiring.connect(m, wiring.flipped(self.i), rect_to_polar.i)
+        connect_magnitude_to_sq(m, rect_to_polar.o, block_lpf.i)
+        wiring.connect(m, block_lpf.o, wiring.flipped(self.o))
+        return m
+
+class SpectralCrossSynthesis(wiring.Component):
+
+    """Apply the spectral envelope of 'modulator' on a 'carrier'.
+
+    Consume 2 sets of frequency-domain spectra (blocks) representing a
+    'carrier' and 'modulator'. The (real) envelope of the 'modulator'
+    spectra is multiplied by the (complex) 'carrier' spectra, creating
+    a classic vocoder effect where the timbre of the 'carrier' dominates,
+    but is filtered spectrally by the 'modulator'
+
+    This core computes the spectral envelope of the modulator by filtering
+    the magnitude of each frequency band, see :class:`SpectralEnvelope` for details.
+    Put simply, this core computes:
+
+    .. code-block:: text
+
+        out.real = carrier.real * modulator.envelope_magnitude
+        out.imag = carrier.imag * modulator.envelope_magnitude
+
+    Members
+    -------
+    i_carrier : :py:`In(stream.Signature(Block(CQ(self.shape))))`
+        Incoming stream of blocks of complex spectra of the 'carrier'.
+    i_modulator : :py:`In(stream.Signature(Block(CQ(self.shape))))`
+        Incoming stream of blocks of complex spectra of the 'modulator'.
+    o : :py:`Out(stream.Signature(Block(CQ(self.shape))))`
+        Outgoing stream of cross-synthesized 'carrier' and 'modulator'.
+    """
+
+    def __init__(self,
+                 shape: fixed.Shape,
+                 sz: int):
+        """
+        shape : Shape
+            Shape of fixed-point number to use for block streams.
+        sz : int
+            Size of each block of complex spectra.
+        """
+        self.shape = shape
+        self.sz    = sz
+        super().__init__({
+            # All frequency domain spectra in blocks.
+            "i_carrier": In(stream.Signature(Block(CQ(self.shape)))),
+            "i_modulator": In(stream.Signature(Block(CQ(self.shape)))),
+            "o": Out(stream.Signature(Block(CQ(self.shape)))),
+        })
+
+    def elaborate(self, platform) -> Module:
+        m = Module()
+
+        # Connect modulator spectra to spectral envelope detector
+
+        m.submodules.spectral_envelope = spectral_envelope = SpectralEnvelope(
+            shape=self.shape, sz=self.sz)
+        wiring.connect(m, wiring.flipped(self.i_modulator), spectral_envelope.i)
+
+        # Time-synchronize output of 'spectral_envelope' with 'i_carrier' by
+        # merging these two streams together, so we can multiply them pointwise.
+
+        m.submodules.merge2 = merge2 = dsp.Merge(n_channels=2, shape=self.i_carrier.payload.shape())
+        wiring.connect(m, wiring.flipped(self.i_carrier), merge2.i[0])
+        dsp.connect_remap(m, spectral_envelope.o, merge2.i[1], lambda o, i : [
+            i.payload.sample.real.eq(o.payload.sample),
+            i.payload.first.eq(o.payload.first),
+        ])
+
+        # Shared multiplier for carrier * mag(modulator) terms
+
+        modulator_a = Signal(self.shape)
+        modulator_b = Signal(self.shape)
+        modulator_z = Signal(self.shape)
+        m.d.comb += modulator_z.eq((modulator_a * modulator_b)<<3)
+
+        # Input latch
+        l_carrier   = Signal.like(self.i_carrier.payload.sample)
+        l_first     = Signal()
+
+        with m.FSM():
+            with m.State("IDLE"):
+                # Wait for time-synchronized carrier and spectral envelope block
+                m.d.comb += merge2.o.ready.eq(1)
+                with m.If(merge2.o.valid):
+                    m.d.sync += [
+                        l_carrier.eq(merge2.o.payload[0].sample),
+                        modulator_b.eq(merge2.o.payload[1].sample.real),
+                        # TODO frame alignment (not needed for STFT cores
+                        # with shared reset.)
+                        l_first.eq(merge2.o.payload[0].first),
+                    ]
+                    m.next = "REAL"
+
+            # Multiply real/imag components of carrier by modulator spectra
+            # computed by SpectralEnvelope, pointwise
+
+            with m.State("REAL"):
+                m.d.comb += modulator_a.eq(l_carrier.real)
+                m.d.sync += self.o.payload.sample.real.eq(modulator_z)
+                m.next = "IMAG"
+
+            with m.State("IMAG"):
+                m.d.comb += modulator_a.eq(l_carrier.imag)
+                m.d.sync += self.o.payload.sample.imag.eq(modulator_z)
+                m.next = "OUTPUT"
+
+            with m.State("OUTPUT"):
+                m.d.comb += [
+                    self.o.valid.eq(1),
+                    self.o.payload.first.eq(l_first),
+                ]
+                with m.If(self.o.ready):
+                    m.next = "IDLE"
+
+        return m

--- a/gateware/tests/test_cordic.py
+++ b/gateware/tests/test_cordic.py
@@ -1,0 +1,98 @@
+import sys
+import math
+import unittest
+
+from amaranth              import *
+from amaranth.sim          import *
+from amaranth.utils        import exact_log2
+from amaranth.lib          import wiring
+
+from amaranth_future       import fixed
+
+from tiliqua.eurorack_pmod import ASQ
+from tiliqua               import cordic
+
+class CordicTests(unittest.TestCase):
+
+    SHAPE = ASQ
+
+    def test_cordic_vector(self):
+
+        dut = cordic.RectToPolarCordic(self.SHAPE)
+
+        async def send_complex(ctx, real, imag):
+            ctx.set(dut.i.payload.sample.real, fixed.Const(real, shape=self.SHAPE, clamp=True))
+            ctx.set(dut.i.payload.sample.imag, fixed.Const(imag, shape=self.SHAPE, clamp=True))
+            ctx.set(dut.i.valid, 1)
+            while not ctx.get(dut.i.ready):
+                await ctx.tick()
+            await ctx.tick()
+            ctx.set(dut.i.valid, 0)
+
+        async def receive_result(ctx):
+            while not ctx.get(dut.o.valid):
+                await ctx.tick()
+            mag = ctx.get(dut.o.payload.sample.magnitude).as_float()
+            phase = ctx.get(dut.o.payload.sample.phase).as_float()
+            ctx.set(dut.o.ready, 1)
+            await ctx.tick()
+            ctx.set(dut.o.ready, 0)
+            return mag, phase
+
+        async def test_case(ctx, real, imag, name=""):
+            # Calculate expected values
+            expected_mag = math.sqrt(real**2 + imag**2)
+            expected_phase = math.atan2(imag, real)/math.pi
+            # Send stimulus, wait for result
+            await send_complex(ctx, real, imag)
+            mag, phase = await receive_result(ctx)
+            # Calculate and print errors
+            mag_error = abs(mag - expected_mag)
+            phase_error = abs(phase - expected_phase)
+            print(f"\n{name}")
+            print(f"  Input: ({real:.4f}, {imag:.4f})")
+            print(f"  Expected: mag={expected_mag:.4f}, phase={expected_phase:.4f} * pi")
+            print(f"  Got:      mag={mag:.4f}, phase={phase:.4f} * pi")
+            print(f"  Error:    mag={mag_error:.6f}, phase={phase_error:.6f} * pi")
+            # Check for reasonable accuracy (considering fixed-point limitations)
+            self.assertLess(mag_error, 0.01, f"Magnitude error too large for {name}")
+            self.assertLess(phase_error, 0.01, f"Phase error too large for {name}")
+            return mag, phase
+
+        async def testbench(ctx):
+            # Reset
+            ctx.set(dut.o.ready, 0)
+            ctx.set(dut.i.valid, 0)
+            await ctx.tick().repeat(2)
+            # Cover all quadrants and some edge cases
+            test_cases = [
+                # Quadrant 1
+                (1.0, 0.0, "Positive real axis"),
+                (0.0, 1.0, "Positive imaginary axis"),
+                (0.707, 0.707, "45 degrees"),
+                (0.5, 0.866, "60 degrees"),
+                # Quadrant 2
+                (-1.0, 0.0, "Negative real axis"),
+                (-0.707, 0.707, "135 degrees"),
+                # Quadrant 3
+                (-0.707, -0.707, "225 degrees"),
+                (-0.5, -0.866, "240 degrees"),
+                # Quadrant 4
+                (0.0, -1.0, "Negative imaginary axis"),
+                (0.707, -0.707, "315 degrees"),
+                # Small values
+                (0.1, 0.1, "Small values"),
+                # Near maximum values (considering fixed point range)
+                (1.0, 1.0, "Large values"),
+                (-1.0, 1.0, "Large values"),
+            ]
+            for real, imag, name in test_cases:
+                await test_case(ctx, real, imag, name)
+                # Wait a few cycles between tests
+                await ctx.tick().repeat(5)
+
+        sim = Simulator(dut)
+        sim.add_clock(1e-6)
+        sim.add_testbench(testbench)
+        with sim.write_vcd(vcd_file=open(f"test_cordic.vcd", "w")):
+            sim.run()

--- a/gateware/tests/test_fft.py
+++ b/gateware/tests/test_fft.py
@@ -1,0 +1,213 @@
+import sys
+import unittest
+
+from math import cos, sin, pi
+
+from amaranth              import *
+from amaranth.sim          import *
+from amaranth.utils        import exact_log2
+from amaranth.lib          import wiring
+
+from amaranth_future       import fixed
+
+from tiliqua.eurorack_pmod import ASQ
+from tiliqua               import dsp, fft
+
+from parameterized         import parameterized
+import numpy as np
+
+FFT_SZ = 16
+
+class FFTTests(unittest.TestCase):
+
+    @parameterized.expand([
+        ["r_impulse", FFT_SZ, fixed.SQ(2, 30),
+         lambda n: 1 if n == 0 else 0],
+        ["i_impulse", FFT_SZ, fixed.SQ(2, 30),
+         lambda n: 1j if n == 0 else 0],
+        ["all_zero", FFT_SZ, fixed.SQ(2, 30),
+         lambda n: 0],
+        ["r_all_one", FFT_SZ, fixed.SQ(2, 30),
+         lambda n: 1],
+        ["i_all_one", FFT_SZ, fixed.SQ(2, 30),
+         lambda n: 1j],
+        ["r_alternate", FFT_SZ, fixed.SQ(2, 30),
+         lambda n: 1.0 if n % 2 == 0 else -1.0],
+        ["i_alternate", FFT_SZ, fixed.SQ(2, 30),
+         lambda n: 1j if n % 2 == 0 else -1j],
+        ["e_even", FFT_SZ, fixed.SQ(2, 30),
+         lambda n: cos(8*2*np.pi*n/FFT_SZ) + 1j * sin(8*2*np.pi*n/FFT_SZ)],
+        ["e_fraction", FFT_SZ, fixed.SQ(2, 30),
+         lambda n: cos((43./7)*2*np.pi*n/FFT_SZ) + 1j * sin((43./7)*2*np.pi*n/FFT_SZ)],
+        ["r_cos_fraction", FFT_SZ, fixed.SQ(2, 30),
+         lambda n: cos((43./7)*2*np.pi*n/FFT_SZ)],
+        ["r_cos_fraction_small", FFT_SZ, fixed.SQ(2, 30),
+         lambda n: 0.1*cos((43./7)*2*np.pi*n/FFT_SZ)],
+        ["i_cos_fraction", FFT_SZ, fixed.SQ(2, 30),
+         lambda n: 1j*cos((43./7)*2*np.pi*n/FFT_SZ)],
+        ["r_sin_fraction", FFT_SZ, fixed.SQ(2, 30),
+         lambda n: sin((43./7)*2*np.pi*n/FFT_SZ)],
+        ["i_sin_fraction", FFT_SZ, fixed.SQ(2, 30),
+         lambda n: 1j*sin((43./7)*2*np.pi*n/FFT_SZ)],
+        ["r_pulse", FFT_SZ, fixed.SQ(2, 30),
+         lambda n: 1 if n < 4 else 0],
+    ])
+    def test_fft(self, name, sz, shape, stimulus_function):
+
+        """
+        For a set of stimuli, verify:
+        1) The frequency response of our forward fft is numerically close to
+           the frequency response of ``numpy.fft`` for the same time domain input.
+        2) The time-domain signal after having passed through an ``ifft(fft(x))``
+           round trip is numerically close to the original time domain signal.
+        """
+
+        m = Module()
+        dut = fft.FFT(sz=sz, shape=shape)
+        ifft = fft.FFT(sz=sz, shape=shape)
+        wiring.connect(m, dut.o, ifft.i)
+        m.d.comb += ifft.ifft.eq(1)
+        m.d.comb += ifft.o.ready.eq(1)
+        m.submodules.dut = dut
+        m.submodules.ifft = ifft
+
+        def stimulus_values():
+            for n in range(0, sys.maxsize):
+                yield (fixed.Const((stimulus_function(n)+0*1j).real, shape=shape),
+                       fixed.Const((stimulus_function(n)+0*1j).imag, shape=shape))
+
+        async def stimulus_i(ctx):
+            s = stimulus_values()
+            while True:
+                ctx.set(dut.i.payload.first, 1)
+                for _ in range(sz):
+                    await ctx.tick().until(dut.i.ready)
+                    real, imag = next(s)
+                    ctx.set(dut.i.valid, 1)
+                    ctx.set(dut.i.payload.sample.real, real)
+                    ctx.set(dut.i.payload.sample.imag, imag)
+                    await ctx.tick()
+                    ctx.set(dut.i.valid, 0)
+                    ctx.set(dut.i.payload.first, 0)
+                    await ctx.tick()
+
+        async def testbench(ctx):
+            s_i = []
+            s_f = []
+            s_o = []
+            def complex_from_payload(payload):
+                return (ctx.get(payload.sample.real).as_float() +
+                        1j * ctx.get(payload.sample.imag).as_float())
+            while True:
+                # Three tap-off points used for validation - before the
+                # fft, after the fft, and after the ifft(fft(x)) round trip.
+                if ctx.get(dut.i.valid & dut.i.ready):
+                    # forward FFT inputs
+                    s_i.append(complex_from_payload(dut.i.payload))
+                if ctx.get(dut.o.valid & dut.o.ready):
+                    # forward FFT outputs (frequency domain)
+                    s_f.append(complex_from_payload(dut.o.payload))
+                if ctx.get(ifft.o.valid & ifft.o.ready):
+                    # inverse FFT outputs (should match original signal)
+                    s_o.append(complex_from_payload(ifft.o.payload))
+                    if len(s_o) == sz:
+                        break
+                await ctx.tick()
+
+            # Convert results into numpy arrays of complex type. The simulation
+            # may have fed more than 1 block into the fft by the time we have
+            # enough output samples, so only take the first `sz` elements.
+            s_i = np.array(s_i[:sz])
+            s_f = np.array(s_f[:sz])
+            s_o = np.array(s_o[:sz])
+
+            # Validation criteria
+            # Note: these tolerances depend on how wide the fixed point type is
+            s_i_fft = np.fft.fft(s_i, norm="forward")
+            s_freq_delta = np.abs(s_f - s_i_fft)
+            assert np.all(s_freq_delta < 1.5e-9)
+            s_time_delta = np.abs(s_o - s_i)
+            assert np.all(s_time_delta < 1e-8)
+
+        sim = Simulator(m)
+        sim.add_clock(1e-6)
+        sim.add_process(stimulus_i)
+        sim.add_testbench(testbench)
+        with sim.write_vcd(vcd_file=open(f"test_fft_{name}.vcd", "w")):
+            sim.run()
+
+    @parameterized.expand([
+        # 'Small' version of the STFT, with TDM-multiplexed FFT and Window blocks
+        ["dual_cosine_small", 128, fft.STFTProcessor, fixed.SQ(2, 30),
+         lambda n: 0.7*cos(2*pi*n/100) + 0.2*cos(2*pi*n/5)],
+        # 'Large' version of the STFT, independent FFT/IFFT and Windowing blocks
+        ["dual_cosine_pipelined", 128, fft.STFTProcessorPipelined, fixed.SQ(2, 30),
+         lambda n: 0.7*cos(2*pi*n/100) + 0.2*cos(2*pi*n/5)],
+    ])
+    def test_stft(self, name, sz, cls, shape, stimulus_function):
+
+        """
+        Pass a time-domain test waveform through an STFT for resynthesis, connecting
+        the frequency domain output directly to the input.
+
+        The result should be a perfectly reconstructed time-domain signal, despite
+        it having made the round trip through all our components (2x windowing,
+        overlapping, overlap-add blocks, fft and ifft).
+        """
+
+        m = Module()
+        m.submodules.dut = dut = cls(sz=sz, shape=shape)
+        # Passthrough (resynthesize) in frequency domain.
+        wiring.connect(m, dut.o_freq, dut.i_freq)
+        m.d.comb += dut.o.ready.eq(1)
+
+        def stimulus_values():
+            for n in range(0, sys.maxsize):
+                yield fixed.Const(stimulus_function(n), shape=shape)
+
+        async def stimulus_i(ctx):
+            s = stimulus_values()
+            while True:
+                await ctx.tick().until(dut.i.ready)
+                ctx.set(dut.i.valid, 1)
+                ctx.set(dut.i.payload, next(s))
+                await ctx.tick()
+                ctx.set(dut.i.valid, 0)
+                await ctx.tick()
+
+        async def testbench(ctx):
+            N = sz
+            samples_i = []
+            samples_o = []
+            while True:
+                if ctx.get(dut.i.valid & dut.i.ready):
+                    samples_i.append(ctx.get(dut.i.payload).as_float())
+                if ctx.get(dut.o.valid & dut.o.ready):
+                    samples_o.append(ctx.get(dut.o.payload).as_float())
+                    if len(samples_o) == 2*N:
+                        break
+                await ctx.tick()
+            # After 1 block of 'ramp-up' (zero-padded samples coming
+            # from overlap-add reconstruction), verify the output perfectly
+            # matches the input time-domain signal.
+            s_i = np.array(samples_i[N:2*N], dtype=float)
+            s_o = np.array(samples_o[N:2*N], dtype=float)
+            s_io_delta = np.abs(s_o - s_i)
+            print("Maximum difference between in/out samples:", max(s_io_delta))
+            assert np.all(s_io_delta < 1e-7)
+            """
+            # Uncomment to see the input and output waveforms plotted. it's fun to
+            # slice from 0 rather than N in samples_i/o, to see the ramp-up.
+            import matplotlib.pyplot as plt
+            plt.plot(s_i)
+            plt.plot(s_o)
+            plt.plot(s_o-s_i)
+            plt.show()
+            """
+
+        sim = Simulator(m)
+        sim.add_clock(1.667e-8)
+        sim.add_process(stimulus_i)
+        sim.add_testbench(testbench)
+        with sim.write_vcd(vcd_file=open(f"test_stft_{name}.vcd", "w")):
+            sim.run()


### PR DESCRIPTION
## Frequency-domain DSP cores

This PR implements loads of new cores required for frequency-domain processing, such as:
- Helpers for block-based processing and streaming complex numbers
  - `Block` abstraction for blocks of samples. `CQ` and `Polar` abstractions for complex numbers.
- A resource efficient FFT (same core can do forward an inverse transform, only needs 2 multipliers)
  - The `FFT` component, taking complex samples, supporting power-of-2 block sizes.
- Window functions
  - The `Window` and `Window.Function` components, currently only `Hann`, `SqrtHann` and `Rect` windows.
- Overlap-add utilities
  - The `ComputeOverlappingBlocks` and `OverlapAddBlocks` components, for analyzing / synthesizing audio signals at higher rates than the FFT block size (also used by the STFT components)
- An STFT implementation for doing analysis/resynthesis of time-domain signals in the frequency domain
  - This includes the `STFTProcessor`, `STFTSynthesizer` and `STFTAnalyzer` as well as `STFTPipelined` components
- A CORDIC for extracting the magnitude from complex spectra
  - The `RectToPolarCordic` for converting between rectangular and polar complex numbers
- Misc. spectral utilities (filtering spectral envelopes, spectral cross-synthesis)
  - The `BlockLPF` component for filtering spectral envelopes
  - The `SpectralEnvelope` component for computing spectral envelopes from complex spectra
  - The `SpectralCrossSynthesis` component for combining two sets of complex spectra together in 'vocoder' fashion.
- Bonus: simple white noise generation core `WhiteNoise`

## Documentation / Examples

I spent quite some time on the docstrings for each core, which will be integrated into the documentation website to help understand what's going on.

A (very) simple example of how all these cores can be used together is provided in the new `Vocoder` top-level bitstream in `src/top/dsp/top.py`, which performs spectral cross-synthesis between two audio streams, for a similar effect to a vocoder. This core uses almost every component added in this PR. In the future, I plan to use these new cores in more bitstreams.

## Testing

Test coverage is added for the FFT, Windowing, Overlap-add, STFT and CORDIC cores. Most cores are tested in combination in the STFT test which verifies we can perfectly reconstruct a time-domain signal.  The spectral cross-synthesis cores are quite difficult to test and as such were only tested on hardware using the new `STFTMirror` and `Vocoder` bitstreams.

### History

The commit history is only short and clean because I imported only the 'working' cores, squashed down from a much messier, longer branch. It took a few weeks to get here :)