### PR TITLE
test/usb: improve `usb_host` integration test

### DIFF
--- a/gateware/.gitignore
+++ b/gateware/.gitignore
@@ -11,6 +11,9 @@ frame*.png
 # lorenz sim dumps
 *lorenz*.png
 
+# usb integration test outputs
+test*.pcap
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
- Simulate `usb_host` gateware against a 'fake' LUNA device by bridging UTMI traffic between the device and host
- Log raw packets exchanged between device and host and log them to a .pcap file for inspection in Packetree or Wireshark.
- Pretty-print packets as they are exchanged between device and host to the terminal.
- Now that the entire enumeration process can complete in the integration test, verify that it has actually completed once the test has finished executing.