### PR TITLE
opts/polysyn: add cc mappings, phase lfo

### DIFF
--- a/gateware/src/rs/hal/src/polysynth.rs
+++ b/gateware/src/rs/hal/src/polysynth.rs
@@ -79,6 +79,10 @@ macro_rules! impl_polysynth {
                     self.registers.release_rate().write(|w| unsafe { w.value().bits(value) } );
                 }
 
+                pub fn set_lfo(&mut self, value: i16)  {
+                    self.registers.lfo().write(|w| unsafe { w.value().bits(value as u16) } );
+                }
+
                 pub fn write_wavetable_sample(&mut self, addr: u16, data: i16)  {
                     self.registers.wt_addr().write(|w| unsafe { w.value().bits(addr) } );
                     self.registers.wt_data().write(|w| unsafe { w.value().bits(data as u16) } );

--- a/gateware/src/rs/lib/src/ui.rs
+++ b/gateware/src/rs/lib/src/ui.rs
@@ -58,6 +58,11 @@ impl<EncoderT: Encoder,
         self.time_since_midi_activity = 0;
     }
 
+    /// Resets the encoder-touched timer so draw/LED feedback activates.
+    pub fn external_modify(&mut self) {
+        self.time_since_encoder_touched = 0;
+    }
+
     pub fn touch_led_mask(&mut self, mask: u8) {
         self.touch_led_mask = mask;
     }

--- a/gateware/src/rs/opts/src/cc_map.rs
+++ b/gateware/src/rs/opts/src/cc_map.rs
@@ -1,0 +1,48 @@
+use heapless::Vec;
+
+#[derive(Clone, Copy)]
+pub enum CcMapMode {
+    Absolute,
+    Decrement,
+    Increment,
+}
+
+#[derive(Clone, Copy)]
+pub struct CcMapping<P: Copy> {
+    pub cc: u8,
+    pub page: P,
+    pub option_key: u32,
+    pub mode: CcMapMode,
+}
+
+pub struct CcAction<P: Copy> {
+    pub page: P,
+    pub option_key: u32,
+    pub cc_value: u8,
+    pub mode: CcMapMode,
+}
+
+pub struct MidiCcMapper<P: Copy, const N: usize> {
+    mappings: Vec<CcMapping<P>, N>,
+}
+
+impl<P: Copy + PartialEq, const N: usize> MidiCcMapper<P, N> {
+    pub fn new() -> Self {
+        Self { mappings: Vec::new() }
+    }
+
+    pub fn add(&mut self, cc: u8, page: P, option_key: u32, mode: CcMapMode) {
+        self.mappings.push(CcMapping { cc, page, option_key, mode }).ok();
+    }
+
+    pub fn process(&self, cc_num: u8, cc_val: u8) -> Option<CcAction<P>> {
+        self.mappings.iter()
+            .find(|m| m.cc == cc_num)
+            .map(|m| CcAction {
+                page: m.page,
+                option_key: m.option_key,
+                cc_value: cc_val,
+                mode: m.mode,
+            })
+    }
+}

--- a/gateware/src/rs/opts/src/integer.rs
+++ b/gateware/src/rs/opts/src/integer.rs
@@ -50,6 +50,7 @@ where
         + Serialize
         + for<'de> Deserialize<'de>
         + AsPrimitive<f32>,
+    f32: AsPrimitive<T::Value>,
 {
     fn name(&self) -> &'static str {
         self.name
@@ -101,6 +102,17 @@ where
     fn n_unique_values(&self) -> usize {
         // TODO
         0
+    }
+
+    fn set_from_cc(&mut self, cc: u8) -> bool {
+        let min_f: f32 = T::MIN.as_();
+        let max_f: f32 = T::MAX.as_();
+        let step_f: f32 = T::STEP.as_();
+        let raw = min_f + (cc as f32 / 127.0) * (max_f - min_f);
+        let quantized = ((raw - min_f) / step_f + 0.5) as u32 as f32 * step_f + min_f;
+        let clamped = quantized.max(min_f).min(max_f);
+        self.value = clamped.as_();
+        true
     }
 
     fn encode(&self, buf: &mut [u8]) -> Option<usize> {

--- a/gateware/src/rs/opts/src/lib.rs
+++ b/gateware/src/rs/opts/src/lib.rs
@@ -11,6 +11,7 @@ mod float;
 mod string;
 mod button;
 pub mod persistence;
+pub mod cc_map;
 
 pub use crate::traits::*;
 pub use crate::integer::*;

--- a/gateware/src/rs/opts/src/traits.rs
+++ b/gateware/src/rs/opts/src/traits.rs
@@ -41,6 +41,8 @@ pub trait OptionTrait {
     fn encode(&self, buf: &mut [u8]) -> Option<usize>;
     fn decode(&mut self, buf: &[u8]) -> bool;
 
+    fn set_from_cc(&mut self, _value: u8) -> bool { false }
+
     /// Handle button press (toggle_modify). Returns true if handled, false otherwise.
     fn button_press(&mut self) -> bool { false }
 }

--- a/gateware/src/top/polysyn/fw/src/main.rs
+++ b/gateware/src/top/polysyn/fw/src/main.rs
@@ -10,6 +10,7 @@ use core::cell::RefCell;
 use micromath::F32Ext;
 use midi_types::*;
 use midi_convert::render_slice::MidiRenderSlice;
+use midi_convert::parse::MidiTryParseSlice;
 
 use tiliqua_pac as pac;
 use tiliqua_hal as hal;
@@ -21,7 +22,8 @@ use pac::constants::*;
 use tiliqua_hal::persist::Persist;
 use tiliqua_fw::*;
 use tiliqua_fw::options::*;
-use opts::Options;
+use opts::{Options, OptionTrait};
+use opts::cc_map::{MidiCcMapper, CcMapMode, CcAction};
 use tiliqua_hal::pmod::EurorackPmod;
 
 use tiliqua_hal::embedded_graphics::prelude::*;
@@ -65,12 +67,25 @@ fn timer0_handler(app: &Mutex<RefCell<App>>) {
         if midi_word != 0 {
             // Blink MIDI activity LED on TRS port
             app.ui.midi_activity();
+
+            let bytes = [
+                (midi_word & 0xFF) as u8,
+                ((midi_word >> 8) & 0xFF) as u8,
+                ((midi_word >> 16) & 0xFF) as u8,
+            ];
+            if let Ok(msg) = MidiMessage::try_parse_slice(&bytes) {
+                if let MidiMessage::ControlChange(_, cc, val) = msg {
+                    if let Some(action) = app.cc_mapper.process(cc.into(), val.into()) {
+                        apply_cc_action(&mut app.ui.opts, &action);
+                        app.ui.external_modify();
+                    }
+                }
+            }
+
             // Optionally dump raw MIDI messages out serial port.
             if opts.misc.serial_debug.value == UsbMidiSerialDebug::On {
                 info!("midi: 0x{:x} 0x{:x} 0x{:x}",
-                      midi_word&0xff,
-                      (midi_word>>8)&0xff,
-                      (midi_word>>16)&0xff);
+                      bytes[0], bytes[1], bytes[2]);
             }
         }
 
@@ -86,7 +101,7 @@ fn timer0_handler(app: &Mutex<RefCell<App>>) {
         }
 
         // Map 0-1 UI range to 32768-8192 hardware range (inverted)
-        let reso_ui = opts.effect.reso.value as u32;
+        let reso_ui = opts.voice.reso.value as u32;
         let reso_hw = (32768 - reso_ui * 24576 / 32768) as u16;
         let reso_smooth = app.reso_smoother.proc_u16(reso_hw);
         app.synth.set_reso(reso_smooth);
@@ -111,16 +126,31 @@ fn timer0_handler(app: &Mutex<RefCell<App>>) {
         app.synth.set_sustain_level((opts.adsr.sustain.value as u32 * 65535 / 32768) as u16);
         app.synth.set_release_rate(adsr_ui_to_rate(opts.adsr.release.value));
 
-        // Wavetable update on parameter change
-        if opts.osc.waveform.value != app.last_waveform
-            || opts.osc.proc.value != app.last_proc_mode
-            || opts.osc.proc_amt.value != app.last_proc_amt
+        // LFO -> phase modulation CSR
         {
-            wavetable::wt_write(&mut app.synth, opts.osc.waveform.value,
-                                opts.osc.proc.value, opts.osc.proc_amt.value);
-            app.last_waveform = opts.osc.waveform.value;
-            app.last_proc_mode = opts.osc.proc.value;
-            app.last_proc_amt = opts.osc.proc_amt.value;
+            use wavetable::{Fix32, CYCLE_LEN};
+            let isr_rate = Fix32::from_num(1000u32 / TIMER0_ISR_PERIOD_MS);
+            // lfo_rate option: 0..50 -> 0..5.0 Hz
+            // Q16.16 from_bits: value * 65536 / 10 = value * 6554
+            let rate_hz = Fix32::from_bits(opts.voice.lfo_rate.value as i32 * 6554);
+            let phase_inc = rate_hz * CYCLE_LEN as i32 / isr_rate;
+            // depth option: 0..32768 -> 0..1.0
+            let depth = Fix32::from_bits(opts.voice.lfo_depth.value as i32 * 2);
+            let lfo_val = wavetable::wt_lfo(&mut app.lfo_phase, phase_inc, depth,
+                                           Waveform::Sine);
+            app.synth.set_lfo(lfo_val);
+        }
+
+        // Wavetable update on parameter change
+        if opts.voice.waveform.value != app.last_waveform
+            || opts.voice.proc.value != app.last_proc_mode
+            || opts.voice.proc_amt.value != app.last_proc_amt
+        {
+            wavetable::wt_write(&mut app.synth, opts.voice.waveform.value,
+                                opts.voice.proc.value, opts.voice.proc_amt.value);
+            app.last_waveform = opts.voice.waveform.value;
+            app.last_proc_mode = opts.voice.proc.value;
+            app.last_proc_amt = opts.voice.proc_amt.value;
         }
 
         // Touch controller logic (sends MIDI to internal polysynth)
@@ -145,6 +175,44 @@ fn timer0_handler(app: &Mutex<RefCell<App>>) {
     });
 }
 
+fn apply_cc_action(opts: &mut Opts, action: &CcAction<Page>) {
+    opts.tracker.page.value = action.page;
+    let index = opts.view().options().iter()
+        .position(|opt| opt.key().value() == action.option_key);
+    if let Some(i) = index {
+        opts.set_selected(Some(i));
+        let opt = &mut opts.view_mut().options_mut()[i];
+        match action.mode {
+            CcMapMode::Absolute => { opt.set_from_cc(action.cc_value); }
+            CcMapMode::Decrement => { opt.tick_down(); }
+            CcMapMode::Increment => { opt.tick_up(); }
+        }
+    }
+}
+
+fn build_cc_mapper(opts: &Opts) -> MidiCcMapper<Page, 16> {
+    let mut m = MidiCcMapper::new();
+    // Effect page
+    m.add(74, Page::Effect, opts.effect.drive.key().value(),   CcMapMode::Absolute);
+    m.add(71, Page::Voice, opts.voice.reso.key().value(),     CcMapMode::Absolute);
+    m.add(17, Page::Effect, opts.effect.diffuse.key().value(), CcMapMode::Absolute);
+    // Osc page
+    m.add(22, Page::Voice, opts.voice.waveform.key().value(), CcMapMode::Decrement);
+    m.add(23, Page::Voice, opts.voice.waveform.key().value(), CcMapMode::Increment);
+    m.add(24, Page::Voice, opts.voice.proc.key().value(),     CcMapMode::Decrement);
+    m.add(25, Page::Voice, opts.voice.proc.key().value(),     CcMapMode::Increment);
+    m.add(93, Page::Voice, opts.voice.proc_amt.key().value(), CcMapMode::Absolute);
+    // Voice page LFO
+    m.add(76, Page::Voice, opts.voice.lfo_depth.key().value(), CcMapMode::Absolute);
+    m.add(77, Page::Voice, opts.voice.lfo_rate.key().value(),  CcMapMode::Absolute);
+    // ADSR page
+    m.add(73, Page::Adsr, opts.adsr.attack.key().value(),  CcMapMode::Absolute);
+    m.add(75, Page::Adsr, opts.adsr.decay.key().value(),   CcMapMode::Absolute);
+    m.add(79, Page::Adsr, opts.adsr.sustain.key().value(), CcMapMode::Absolute);
+    m.add(72, Page::Adsr, opts.adsr.release.key().value(), CcMapMode::Absolute);
+    m
+}
+
 struct App {
     ui: ui::UI<Encoder0, EurorackPmod0, I2c0, Opts>,
     synth: Polysynth0,
@@ -152,9 +220,14 @@ struct App {
     reso_smoother: OnePoleSmoother,
     diffusion_smoother: OnePoleSmoother,
     touch_controller: MidiTouchController,
+    // wavetable state
     last_waveform: Waveform,
     last_proc_mode: ProcMode,
     last_proc_amt: u16,
+    // midi cc mapper
+    cc_mapper: MidiCcMapper<Page, 16>,
+    // lfo phase accumulator
+    lfo_phase: wavetable::Fix32,
 }
 
 impl App {
@@ -169,6 +242,7 @@ impl App {
         let reso_smoother = OnePoleSmoother::new(0.05f32);
         let diffusion_smoother = OnePoleSmoother::new(0.05f32);
         let touch_controller = MidiTouchController::new();
+        let cc_mapper = build_cc_mapper(&opts);
         Self {
             ui: ui::UI::new(opts, TIMER0_ISR_PERIOD_MS,
                             encoder, pca9635, pmod),
@@ -180,6 +254,8 @@ impl App {
             last_waveform: Waveform::default(),
             last_proc_mode: ProcMode::default(),
             last_proc_amt: 0,
+            cc_mapper,
+            lfo_phase: wavetable::Fix32::ZERO,
         }
     }
 }
@@ -370,12 +446,12 @@ fn main() -> ! {
                         opts.beam.hue.value,
                         highlight).ok();
                 }
-                if opts.tracker.page.value == Page::Osc {
+                if opts.tracker.page.value == Page::Voice {
                     const PREVIEW_LEN: usize = 64;
                     let mut preview = [0i16; PREVIEW_LEN];
                     wavetable::wt_preview(&mut preview,
-                        opts.osc.waveform.value, opts.osc.proc.value,
-                        opts.osc.proc_amt.value);
+                        opts.voice.waveform.value, opts.voice.proc.value,
+                        opts.voice.proc_amt.value);
                     draw::draw_waveform_preview(&mut display,
                         h_active/2-190, 80,
                         125, 40,

--- a/gateware/src/top/polysyn/fw/src/options.rs
+++ b/gateware/src/top/polysyn/fw/src/options.rs
@@ -10,7 +10,7 @@ use tiliqua_lib::scope::VScale;
 pub enum Page {
     #[default]
     Help,
-    Osc,
+    Voice,
     Adsr,
     Effect,
     Beam,
@@ -79,7 +79,9 @@ int_params!(PersistParams<u16>    { step: 32, min: 32, max: 4096 });
 int_params!(DecayParams<u8>       { step: 1, min: 0, max: 15 });
 int_params!(IntensityParams<u8>   { step: 1, min: 0, max: 15 });
 int_params!(HueParams<u8>         { step: 1, min: 0, max: 15 });
-int_params!(ScrollParams<u8>      { step: 1, min: 0, max: 60 });
+int_params!(ScrollParams<u8>      { step: 1, min: 0, max: 80 });
+int_params!(LfoRateParams<u16>   { step: 2, min: 0, max: 50, format: IntFormat::Scaled { divisor: 10, precision: 1, suffix: "hz" } });
+int_params!(LfoDepthParams<u16>  { step: 2048, min: 0, max: 32768, format: IntFormat::Scaled { divisor: 32768, precision: 2, suffix: "" } });
 
 button_params!(OneShotButtonParams { mode: ButtonMode::OneShot });
 
@@ -90,28 +92,32 @@ pub struct HelpOpts {
 }
 
 #[derive(OptionPage, Clone)]
-pub struct OscOpts {
+pub struct VoiceOpts {
     #[option]
     pub waveform: EnumOption<Waveform>,
     #[option]
     pub proc: EnumOption<ProcMode>,
     #[option(10)]
     pub proc_amt: IntOption<ProcAmtParams>,
+    #[option(16384)]
+    pub reso: IntOption<ResoParams>,
+    #[option(1)]
+    pub lfo_rate: IntOption<LfoRateParams>,
+    #[option(3277)]
+    pub lfo_depth: IntOption<LfoDepthParams>,
 }
 
 #[derive(OptionPage, Clone)]
 pub struct EffectOpts {
     #[option(8192)]
     pub drive: IntOption<DriveParams>,
-    #[option(16384)]
-    pub reso: IntOption<ResoParams>,
     #[option(12288)]
     pub diffuse: IntOption<DiffuseParams>,
 }
 
 #[derive(OptionPage, Clone)]
 pub struct AdsrOpts {
-    #[option(1024)]
+    #[option(0)]
     pub attack: IntOption<AdsrTimeParams>,
     #[option(4096)]
     pub decay: IntOption<AdsrTimeParams>,
@@ -156,8 +162,8 @@ pub struct Opts {
     pub tracker: ScreenTracker<Page>,
     #[page(Page::Help)]
     pub help: HelpOpts,
-    #[page(Page::Osc)]
-    pub osc: OscOpts,
+    #[page(Page::Voice)]
+    pub voice: VoiceOpts,
     #[page(Page::Adsr)]
     pub adsr: AdsrOpts,
     #[page(Page::Effect)]

--- a/gateware/src/top/polysyn/fw/src/wavetable.rs
+++ b/gateware/src/top/polysyn/fw/src/wavetable.rs
@@ -141,6 +141,17 @@ pub fn wt_preview(buf: &mut [i16], waveform: Waveform,
     }
 }
 
+pub fn wt_lfo(phase: &mut Fix32, phase_inc: Fix32, depth: Fix32, waveform: Waveform) -> i16 {
+    let idx = phase.to_num::<usize>() % CYCLE_LEN;
+    let sample = wt_sample(waveform, idx, CYCLE_LEN) * depth;
+    *phase = *phase + phase_inc;
+    let cycle_len = Fix32::from_num(CYCLE_LEN);
+    if *phase >= cycle_len {
+        *phase -= cycle_len;
+    }
+    to_asq(sample)
+}
+
 pub fn wt_write(synth: &mut Polysynth0, waveform: Waveform,
                 proc_mode: ProcMode, proc_amt: u16) {
     let gain = gain_from_amt(proc_amt);

--- a/gateware/src/top/polysyn/top.py
+++ b/gateware/src/top/polysyn/top.py
@@ -70,9 +70,36 @@ the UI.
                                   │OUT (4x)├──────► out2 (L)
                                   └────────┴──────► out3 (R)
 
-The OSC page allows selection between many wavetables. The 'proc' option
+The VOICE page allows selection between many wavetables. The 'proc' option
 allows applying effects (e.g. saturation, wavefolding, rectify) to
-the wavetable **before** it hits the voice filter.
+the wavetable **before** it hits the voice filter. When no CV is patched
+into input 0, a built-in sine LFO modulates the phase of all voices
+(rate and depth are adjustable on the VOICE page).
+
+The following MIDI CC mappings are supported:
+
+    .. code-block:: text
+
+        CC  Parameter       Mode
+        ──  ─────────       ────
+         1  mod wheel       filter cutoff
+        64  sustain pedal   hold voices
+        22  waveform        prev
+        23  waveform        next
+        24  proc mode       prev
+        25  proc mode       next
+        93  proc amount     absolute
+        71  resonance       absolute
+        76  lfo depth       absolute
+        77  lfo rate        absolute
+        73  attack          absolute
+        75  decay           absolute
+        79  sustain         absolute
+        72  release         absolute
+        74  drive           absolute
+        17  diffuse         absolute
+
+    Pitch bend is also supported.
 
 """
 
@@ -153,6 +180,8 @@ class PolySynth(wiring.Component):
     wt_write_data: In(signed(16))
     wt_write_en: In(unsigned(1))
 
+    lfo: In(ASQ)
+
     # Jack detection (directly from pmod hardware)
     jack: In(unsigned(8))
 
@@ -181,9 +210,17 @@ class PolySynth(wiring.Component):
         with m.If(self.i.valid):
             m.d.sync += cv.eq(self.i.payload)
 
-        # CV 0: phase modulation (when jack 0 patched)
+        m.submodules.lfo_lpf = lfo_lpf = dsp.OnePole()
+        m.d.comb += [
+            lfo_lpf.i.payload.eq(self.lfo),
+            lfo_lpf.i.valid.eq(self.i.valid),
+            lfo_lpf.o.ready.eq(1),
+            lfo_lpf.shift.eq(6),
+        ]
+
+        # CV 0: phase modulation (when jack 0 patched, otherwise use LFO)
         m.d.comb += voice_block.phase_mod.eq(
-            Mux(self.jack[0], cv[0], 0))
+            Mux(self.jack[0], cv[0], lfo_lpf.o.payload))
 
         # CV 1: velocity_mod override (when jack 1 patched)
         cv1_u8 = Signal(unsigned(8))
@@ -295,6 +332,9 @@ class SynthPeripheral(wiring.Component):
     class ReleaseRate(csr.Register, access="w"):
         value: csr.Field(csr.action.W, unsigned(16))
 
+    class Lfo(csr.Register, access="w"):
+        value: csr.Field(csr.action.W, signed(16))
+
     class WavetableAddr(csr.Register, access="w"):
         value: csr.Field(csr.action.W, unsigned(16))
 
@@ -350,6 +390,7 @@ class SynthPeripheral(wiring.Component):
         self._release_rate  = regs.add("release_rate",  self.ReleaseRate(),   offset=voices_csr_end + 0x28)
         self._wt_addr       = regs.add("wt_addr",       self.WavetableAddr(), offset=voices_csr_end + 0x2C)
         self._wt_data       = regs.add("wt_data",       self.WavetableData(), offset=voices_csr_end + 0x30)
+        self._lfo           = regs.add("lfo",           self.Lfo(),           offset=voices_csr_end + 0x34)
         self._bridge = csr.Bridge(regs.as_memory_map())
         super().__init__({
             "bus": In(csr.Signature(addr_width=regs.addr_width, data_width=regs.data_width)),
@@ -380,6 +421,9 @@ class SynthPeripheral(wiring.Component):
             m.d.sync += self.synth.sustain_level.eq(self._sustain_level.f.value.w_data)
         with m.If(self._release_rate.f.value.w_stb):
             m.d.sync += self.synth.release_rate.eq(self._release_rate.f.value.w_data)
+
+        with m.If(self._lfo.f.value.w_stb):
+            m.d.sync += self.synth.lfo.as_value().eq(self._lfo.f.value.w_data)
 
         # Wavetable write: latch address on addr write, commit on data write
         wt_addr_reg = Signal(9)


### PR DESCRIPTION
Add MIDI CC mappings to `polysyn`, document them, and add a phase LFO when input 0 is not patched
* add cc mapping in opts library (only used in polysyn at the moment)
* top/polysyn: move reso to VOICE page
* top/polysyn: add sine lfo, final cc mappings