### PR TITLE
mode line config for the "52Pi 7 Inch HDMI IPS Display"

### DIFF
--- a/gateware/src/tiliqua/video/modeline.py
+++ b/gateware/src/tiliqua/video/modeline.py
@@ -114,6 +114,21 @@ class DVIModeline:
                 pixel_clk_mhz = 74.25,
             ),
 
+            # 52Pi 7 Inch HDMI IPS Display (1024x600px)
+            "1024x600p59.82": DVIModeline(
+                h_active      = 1024,
+                h_sync_start  = 1068,
+                h_sync_end    = 1156,
+                h_total       = 1344,
+                h_sync_invert = False,
+                v_active      = 600,
+                v_sync_start  = 603,
+                v_sync_end    = 609,
+                v_total       = 625,
+                v_sync_invert = True,
+                pixel_clk_mhz = 50.25,
+            ),
+
             # BEGIN ODDBALL TIMINGS
 
             # Tiliqua screen (early proto)
@@ -222,6 +237,17 @@ class DVIPLL:
                 clkos_div     = 19,
                 clkos_cphase  = 0,
                 clkos2_div    = 95,
+                clkos2_cphase = 0,
+                clkfb_div     = 4
+            ),
+            DVIPLL(
+                pixel_clk_mhz = 50.25,
+                clki_div      = 13,
+                clkop_div     = 34,
+                clkop_cphase  = 9,
+                clkos_div     = 2,
+                clkos_cphase  = 0,
+                clkos2_div    = 10,
                 clkos2_cphase = 0,
                 clkfb_div     = 4
             ),

--- a/gateware/src/tiliqua/video/modeline.py
+++ b/gateware/src/tiliqua/video/modeline.py
@@ -114,6 +114,8 @@ class DVIModeline:
                 pixel_clk_mhz = 74.25,
             ),
 
+            # BEGIN ODDBALL TIMINGS
+
             # 52Pi 7 Inch HDMI IPS Display (1024x600px)
             "1024x600p59.82": DVIModeline(
                 h_active      = 1024,
@@ -128,8 +130,6 @@ class DVIModeline:
                 v_sync_invert = True,
                 pixel_clk_mhz = 50.25,
             ),
-
-            # BEGIN ODDBALL TIMINGS
 
             # Tiliqua screen (early proto)
             "720x720p60proto1": DVIModeline(


### PR DESCRIPTION
mode line config for the [52pi 7" display](https://52pi.com/products/7-inch-800-480-capacitive-touch-display-screen-monitor-for-raspberry-pi)

```
$ xrandr --verbose
  1024x600 (0x256) 50.250MHz +HSync -VSync *current +preferred
        h: width  1024 start 1068 end 1156 total 1344 skew    0 clock  37.39KHz
        v: height  600 start  603 end  609 total  625           clock  59.82Hz
```

```
$ ecppll -i 48  --clkout0 251.25 --highres --reset -f pll60.v
Pll parameters:
Refclk divisor: 13
Feedback divisor: 4
clkout0 divisor: 34
clkout0 frequency: 251.077 MHz
clkout1 divisor: 2
clkout1 frequency: 251.077 MHz
clkout1 phase shift: -1.19414e+35 degrees
VCO frequency: 502.154
```
