### PR TITLE
top/polysyn: add hardware MIDI channel filter on TRS/USB

### DIFF
--- a/gateware/src/rs/hal/src/polysynth.rs
+++ b/gateware/src/rs/hal/src/polysynth.rs
@@ -101,6 +101,12 @@ macro_rules! impl_polysynth {
                     self.registers.usb_midi_cfg().write(|w| unsafe { w.value().bits(cfg_id) } );
                     self.registers.usb_midi_endp().write(|w| unsafe { w.value().bits(endpt_id) } );
                 }
+
+                // `None` listens on all channels.
+                pub fn set_midi_channel_filter(&mut self, channel: Option<u8>)  {
+                    let value = channel.unwrap_or(0);
+                    self.registers.midi_ch_filter().write(|w| unsafe { w.value().bits(value) } );
+                }
             }
         )+
     };

--- a/gateware/src/tiliqua/midi/misc.py
+++ b/gateware/src/tiliqua/midi/misc.py
@@ -164,6 +164,33 @@ class MidiClockDivider(wiring.Component):
 
         return m
 
+class MidiChannelFilter(wiring.Component):
+
+    i: In(stream.Signature(MidiMessage))
+    o: Out(stream.Signature(MidiMessage))
+
+    # 0 = pass all channels; 1..16 = pass only messages on that channel.
+    channel: In(unsigned(5))
+
+    def elaborate(self, platform):
+        m = Module()
+
+        status = self.i.payload.status
+        pass_msg = Signal()
+        m.d.comb += pass_msg.eq(
+            (status.kind == Status.Kind.SYSEX) |
+            (self.channel == 0) |
+            (status.nibble.channel == (self.channel - 1))
+        )
+
+        m.d.comb += [
+            self.o.payload.eq(self.i.payload),
+            self.o.valid.eq(self.i.valid & pass_msg),
+            self.i.ready.eq(Mux(pass_msg, self.o.ready, 1)),
+        ]
+
+        return m
+
 class CCFilter(wiring.Component):
 
     """

--- a/gateware/src/top/polysyn/fw/src/main.rs
+++ b/gateware/src/top/polysyn/fw/src/main.rs
@@ -125,6 +125,8 @@ fn timer0_handler(app: &Mutex<RefCell<App>>) {
         app.synth.set_matrix_coefficient(2, 6, coeff_wet);
         app.synth.set_matrix_coefficient(3, 7, coeff_wet);
 
+        app.synth.set_midi_channel_filter(opts.misc.midi_ch.value.to_filter());
+
         // ADSR params
         app.synth.set_attack_rate(adsr_ui_to_rate(opts.adsr.attack.value));
         app.synth.set_decay_rate(adsr_ui_to_rate(opts.adsr.decay.value));

--- a/gateware/src/top/polysyn/fw/src/options.rs
+++ b/gateware/src/top/polysyn/fw/src/options.rs
@@ -76,6 +76,28 @@ pub enum CcHighlight {
     On,
 }
 
+#[repr(u8)]
+#[derive(Default, Clone, Copy, PartialEq, EnumIter, IntoStaticStr, Serialize, Deserialize)]
+#[strum(serialize_all = "kebab-case")]
+pub enum MidiChannel {
+    #[default]
+    All,
+    Ch1,  Ch2,  Ch3,  Ch4,
+    Ch5,  Ch6,  Ch7,  Ch8,
+    Ch9,  Ch10, Ch11, Ch12,
+    Ch13, Ch14, Ch15, Ch16,
+}
+
+impl MidiChannel {
+    pub fn to_filter(self) -> Option<u8> {
+        match self {
+            /// HAL wants `None` => for listening on all channels.
+            MidiChannel::All => None,
+            _ => Some(self as u8),
+        }
+    }
+}
+
 int_params!(PageNumParams<u16>    { step: 1, min: 0, max: 0 });
 int_params!(ProcAmtParams<u16>   { step: 1, min: 0, max: 50, format: IntFormat::Scaled { divisor: 10, precision: 1, suffix: "" } });
 int_params!(DriveParams<u16>    { step: 2048, min: 0, max: 32768, format: IntFormat::Scaled { divisor: 32768, precision: 2, suffix: "" } });
@@ -154,6 +176,8 @@ pub struct MiscOpts {
     pub touch_ctrl: EnumOption<TouchControl>,
     #[option]
     pub cc_highlight: EnumOption<CcHighlight>,
+    #[option]
+    pub midi_ch: EnumOption<MidiChannel>,
     #[option]
     pub usb_host: EnumOption<UsbHost>,
     #[option]

--- a/gateware/src/top/polysyn/top.py
+++ b/gateware/src/top/polysyn/top.py
@@ -114,6 +114,7 @@ can also be used to control most of these through CCs as follows:
 
         MISC    touch-ctrl     -  enable/disable jacktouch input
         MISC    cc-highlight   -  highlight changed on CC input
+        MISC    midi-ch        -  filter MIDI to specific channel (default: all)
         MISC    usb-host       -  enable USB host MIDI (disables TRS)
         MISC    serial-debug   -  dump MIDI data out serial port
         MISC    save-opts      -  save all options to flash
@@ -388,6 +389,10 @@ class SynthPeripheral(wiring.Component):
         # Hardcoded MIDI streaming endpoint location (device specific)
         value: csr.Field(csr.action.W, unsigned(4))
 
+    class MidiChannelFilter(csr.Register, access="w"):
+        """Channel filter. 0 = no filter, 1..16 = single MIDI channel."""
+        value: csr.Field(csr.action.W, unsigned(5))
+
     def __init__(self, synth=None):
         self.synth = synth
         regs = csr.Builder(addr_width=7, data_width=8)
@@ -410,6 +415,7 @@ class SynthPeripheral(wiring.Component):
         self._wt_addr       = regs.add("wt_addr",       self.WavetableAddr(), offset=voices_csr_end + 0x2C)
         self._wt_data       = regs.add("wt_data",       self.WavetableData(), offset=voices_csr_end + 0x30)
         self._lfo           = regs.add("lfo",           self.Lfo(),           offset=voices_csr_end + 0x34)
+        self._midi_ch_filt  = regs.add("midi_ch_filter",self.MidiChannelFilter(), offset=voices_csr_end + 0x38)
         self._bridge = csr.Bridge(regs.as_memory_map())
         super().__init__({
             "bus": In(csr.Signature(addr_width=regs.addr_width, data_width=regs.data_width)),
@@ -487,6 +493,11 @@ class SynthPeripheral(wiring.Component):
                 self.synth.diffuser.matrix.c.valid.eq(0),
             ]
 
+        m.submodules.midi_ch_filt = midi_ch_filt = midi.MidiChannelFilter()
+        wiring.connect(m, wiring.flipped(self.i_midi), midi_ch_filt.i)
+        with m.If(self._midi_ch_filt.f.value.w_stb):
+            m.d.sync += midi_ch_filt.channel.eq(self._midi_ch_filt.f.value.w_data)
+
         # MIDI injection and arbiter between SoC MIDI and HW MIDI -> synth MIDI.
         m.submodules.soc_midi_fifo = soc_midi_fifo = SyncFIFOBuffered(
             width=24, depth=8)
@@ -494,17 +505,17 @@ class SynthPeripheral(wiring.Component):
             soc_midi_fifo.w_data.eq(self._midi_write.f.msg.w_data),
             soc_midi_fifo.w_en.eq(self._midi_write.element.w_stb),
         ]
-        wiring.connect(m, wiring.flipped(self.i_midi), self.synth.i_midi)
+        wiring.connect(m, midi_ch_filt.o, self.synth.i_midi)
         with m.If(soc_midi_fifo.r_stream.valid):
             wiring.connect(m, soc_midi_fifo.r_stream, self.synth.i_midi)
 
-        # Pipe TRS MIDI -> SoC read FIFO so SoC can inspect external
-        # MIDI traffic
+        # Pipe filtered MIDI -> SoC read FIFO so SoC can inspect external
+        # MIDI traffic.
         m.submodules.read_midi_fifo = read_midi_fifo = SyncFIFOBuffered(
             width=24, depth=8)
         m.d.comb += [
-            read_midi_fifo.w_data.eq(self.i_midi.payload),
-            read_midi_fifo.w_en.eq(self.i_midi.valid & self.i_midi.ready),
+            read_midi_fifo.w_data.eq(midi_ch_filt.o.payload),
+            read_midi_fifo.w_en.eq(midi_ch_filt.o.valid & midi_ch_filt.o.ready),
             read_midi_fifo.r_en.eq(self._midi_read.element.r_stb),
         ]
 


### PR DESCRIPTION
- Add `midi-ch` option to `MISC` page, which can be `all` (default) to listen to all MIDI channels or `ch1, ch2 ...` for listening to a single MIDI channel.

An example build for testing: 
[polysyn-752c419c-r5.tar.gz](https://github.com/user-attachments/files/28422850/polysyn-752c419c-r5.tar.gz)
