### PR TITLE
EXPERIMENT: top/polysyn: experimental mpe support for osmose

### DIFF
--- a/gateware/src/rs/hal/src/polysynth.rs
+++ b/gateware/src/rs/hal/src/polysynth.rs
@@ -105,6 +105,14 @@ macro_rules! impl_polysynth {
                     self.registers.usb_midi_endp().write(|w| unsafe { w.value().bits(endpt_id) } );
                 }
 
+                pub fn set_mpe(&mut self, enable: bool)  {
+                    self.registers.mpe().write(|w| unsafe { w.enable().bit(enable) } );
+                }
+
+                pub fn set_pitch_bend_range(&mut self, semitones: u8)  {
+                    self.registers.pb_range().write(|w| unsafe { w.value().bits(semitones) } );
+                }
+
                 // `None` listens on all channels.
                 pub fn set_midi_channel_filter(&mut self, channel: Option<u8>)  {
                     let value = channel.unwrap_or(0);

--- a/gateware/src/tiliqua/dsp/voice_block.py
+++ b/gateware/src/tiliqua/dsp/voice_block.py
@@ -420,6 +420,19 @@ class MultiSVF(wiring.Component):
         in_first = Signal(1)
         voice_ix = Signal(range(N))
 
+        N_OCTAVES = 5
+        env_scaled = Signal(unsigned(16))
+        octave = env_scaled[-3:]
+        mantissa = env_scaled[:-3]
+        kK_min = (1 << (16 - 3)) >> N_OCTAVES
+        kK_exp = Signal(unsigned(16))
+        kK_shift = Signal(unsigned(3))
+        m.d.comb += [
+            env_scaled.eq((self.i.payload.sample.env.as_value() * N_OCTAVES) >> 3),
+            kK_shift.eq(N_OCTAVES - octave),
+            kK_exp.eq((Cat(mantissa, C(1, 1)) >> kK_shift) - kK_min),
+        ]
+
         with m.FSM():
 
             with m.State('WAIT-VALID'):
@@ -427,7 +440,7 @@ class MultiSVF(wiring.Component):
                 with m.If(self.i.valid):
                     m.d.sync += [
                         svf_x.eq(self.i.payload.sample.x >> 1),
-                        svf_kK.as_value().eq(self.i.payload.sample.env.as_value() >> 3),
+                        svf_kK.as_value().eq(kK_exp),
                         svf_kQinv.as_value().eq(self.reso),
                         in_first.eq(self.i.payload.first),
                         oversample.eq(0),

--- a/gateware/src/tiliqua/midi/voice_tracker.py
+++ b/gateware/src/tiliqua/midi/voice_tracker.py
@@ -21,6 +21,7 @@ class MidiVoice(data.Struct):
     gate:         unsigned(1)
     freq_inc:     ASQ
     velocity_mod: unsigned(8)
+    channel:      unsigned(4)
 
 class MidiVoiceTracker(wiring.Component):
 
@@ -43,14 +44,18 @@ class MidiVoiceTracker(wiring.Component):
     sustained voices have their gates cleared.
     """
 
-    def __init__(self, max_voices=8, velocity_mod=False, zero_velocity_gate=False):
+    def __init__(self, max_voices=8, velocity_mod=False, zero_velocity_gate=False,
+                 master_channel=0):
         self.max_voices = max_voices
         self.velocity_mod = velocity_mod
         self.zero_velocity_gate = zero_velocity_gate
+        self.master_channel = master_channel
         super().__init__({
             "i": In(stream.Signature(MidiMessage)),
             "voice_active": In(data.ArrayLayout(unsigned(1), max_voices)),
             "o": Out(MidiVoice).array(max_voices),
+            "mpe_en": In(unsigned(1)),
+            "pb_scale": In(unsigned(8), init=2),
         });
 
     def elaborate(self, platform):
@@ -73,7 +78,11 @@ class MidiVoiceTracker(wiring.Component):
 
         msg = Signal(MidiMessage)      # last MIDI message
         last_cc1 = Signal(8, init=255) # last cc1 (mod wheel) position
-        last_pb = Signal(shape=ASQ)    # last pitch bend position
+        pb_voice = [Signal(signed(18), name=f"pb_voice_{n}")
+                    for n in range(self.max_voices)]
+
+        pb_factor = fixed.Const(2**(1/12) - 1, shape=ASQ)
+        pb_scaled = Signal(shape=ASQ)
 
         # write index for NOTE_ON select + commit
         voice_ix_write = Signal(range(self.max_voices), init=0)
@@ -87,6 +96,11 @@ class MidiVoiceTracker(wiring.Component):
 
         # freq / mod / pb update index
         ix_update = Signal(range(self.max_voices))
+
+        mpe_press  = [Signal(7, name=f"mpe_press_{n}")
+                      for n in range(self.max_voices)]
+        mpe_timbre = [Signal(7, name=f"mpe_timbre_{n}")
+                      for n in range(self.max_voices)]
 
         # FSM to process incoming MIDI messages one at a time and update
         # internal memories based on these messagse.
@@ -115,6 +129,8 @@ class MidiVoiceTracker(wiring.Component):
                             m.next = 'PITCH-BEND'
                         with m.Case(Status.Kind.POLY_PRESSURE):
                             m.next = 'POLY-PRESSURE'
+                        with m.Case(Status.Kind.CHANNEL_PRESSURE):
+                            m.next = 'CHANNEL-PRESSURE'
                         with m.Default():
                             m.next = 'WAIT-VALID'
 
@@ -126,7 +142,9 @@ class MidiVoiceTracker(wiring.Component):
                     for n in range(self.max_voices):
                         with m.Case(n):
                             m.d.comb += match_found.eq(
-                                self.o[n].note == msg.midi_payload.note_on.note)
+                                (self.o[n].note == msg.midi_payload.note_on.note) &
+                                (~self.mpe_en |
+                                 (self.o[n].channel == msg.status.nibble.channel)))
                 with m.If(match_found):
                     m.next = 'NOTE-ON-COMMIT'
                 with m.Elif(voice_ix_write == self.max_voices - 1):
@@ -173,7 +191,15 @@ class MidiVoiceTracker(wiring.Component):
                                 self.o[n].note.eq(msg.midi_payload.note_on.note),
                                 self.o[n].velocity.eq(msg.midi_payload.note_on.velocity),
                                 self.o[n].gate.eq(1),
+                                self.o[n].channel.eq(msg.status.nibble.channel),
                             ]
+                            m.d.sync += [
+                                mpe_press[n].eq(msg.midi_payload.note_on.velocity),
+                                mpe_timbre[n].eq(0),
+                            ]
+                            with m.If(self.mpe_en &
+                                      (self.o[n].channel != msg.status.nibble.channel)):
+                                m.d.sync += pb_voice[n].eq(0)
                             if not self.velocity_mod:
                                 m.d.sync += self.o[n].velocity_mod.eq(msg.midi_payload.note_on.velocity)
                 m.next = 'UPDATE'
@@ -181,7 +207,9 @@ class MidiVoiceTracker(wiring.Component):
             with m.State('NOTE-OFF'):
                 # cull any voice that matches the MIDI payload note #
                 for n in range(self.max_voices):
-                    with m.If(self.o[n].note == msg.midi_payload.note_off.note):
+                    with m.If((self.o[n].note == msg.midi_payload.note_off.note) &
+                              (~self.mpe_en |
+                               (self.o[n].channel == msg.status.nibble.channel))):
                         with m.If(sustain_held):
                             # pedal held: keep gate, mark for deferred release
                             m.d.sync += sustain_mask.bit_select(n, 1).eq(1)
@@ -202,7 +230,23 @@ class MidiVoiceTracker(wiring.Component):
                         m.d.sync += self.o[n].velocity.eq(msg.midi_payload.poly_pressure.pressure)
                 m.next = 'UPDATE'
 
+            with m.State('CHANNEL-PRESSURE'):
+                with m.If(self.mpe_en):
+                    for n in range(self.max_voices):
+                        with m.If((self.o[n].channel == msg.status.nibble.channel) &
+                                  self.o[n].gate):
+                            m.d.sync += mpe_press[n].eq(
+                                msg.midi_payload.channel_pressure.pressure)
+                m.next = 'UPDATE'
+
             with m.State('CONTROL-CHANGE'):
+                with m.If(self.mpe_en &
+                          (msg.midi_payload.control_change.controller_number == 74)):
+                    for n in range(self.max_voices):
+                        with m.If((self.o[n].channel == msg.status.nibble.channel) &
+                                  self.o[n].gate):
+                            m.d.sync += mpe_timbre[n].eq(
+                                msg.midi_payload.control_change.data)
                 with m.If((msg.midi_payload.control_change.controller_number == 1) &
                           (msg.midi_payload.control_change.data != 0)):
                     m.d.sync += last_cc1.eq(msg.midi_payload.control_change.data)
@@ -233,31 +277,49 @@ class MidiVoiceTracker(wiring.Component):
                 m.next = 'UPDATE'
 
             with m.State('PITCH-BEND'):
-                # convert 14-bit pitch bend to 16-bit signed ASQ -1 .. 1
-                pb = Signal(signed(16))
-                m.d.comb += pb.eq(Cat(msg.midi_payload.pitch_bend.lsb,
-                                      msg.midi_payload.pitch_bend.msb))
-                m.d.sync += last_pb.as_value().eq(pb-(2*8192))
+                pb = Signal(signed(15))
+                m.d.comb += pb.eq(Cat(msg.midi_payload.pitch_bend.lsb[:7],
+                                      msg.midi_payload.pitch_bend.msb[:7]) - 8192)
+                pb_semis = Signal(signed(18))
+                m.d.comb += pb_semis.eq((pb * self.pb_scale) >> 5)
+                with m.If(self.mpe_en &
+                          (msg.status.nibble.channel != self.master_channel)):
+                    for n in range(self.max_voices):
+                        with m.If(self.o[n].channel == msg.status.nibble.channel):
+                            m.d.sync += pb_voice[n].eq(pb_semis)
+                with m.Else():
+                    for n in range(self.max_voices):
+                        m.d.sync += pb_voice[n].eq(pb_semis)
                 m.next = 'UPDATE'
 
             with m.State('UPDATE'):
                 # set LUT not address so we can calculate frequency from it
+                pb_cur = Signal(signed(18))
+                note_cur = Signal(8)
                 with m.Switch(ix_update):
                     for n in range(self.max_voices):
                         with m.Case(n):
-                            m.d.comb += f_lut_rport.addr.eq(self.o[n].note),
+                            m.d.comb += [
+                                note_cur.eq(self.o[n].note),
+                                pb_cur.eq(pb_voice[n]),
+                            ]
+                bent_note = Signal(signed(12))
+                m.d.comb += bent_note.eq(note_cur + (pb_cur >> 8))
+                with m.If(bent_note < 0):
+                    m.d.comb += f_lut_rport.addr.eq(0)
+                with m.Elif(bent_note > 127):
+                    m.d.comb += f_lut_rport.addr.eq(127)
+                with m.Else():
+                    m.d.comb += f_lut_rport.addr.eq(bent_note)
+                pb_residue = Signal(fixed.UQ(0, 8))
+                m.d.comb += pb_residue.as_value().eq(pb_cur[:8])
+                m.d.sync += pb_scaled.eq(pb_factor * pb_residue)
                 m.next = 'UPDATE-FREQ-VEL'
 
             with m.State('UPDATE-FREQ-VEL'):
 
                 # Update linear frequency and velocity based on note values,
                 # pitch bend and (optionally) mod wheel.
-
-                # pitch bend factor
-                pb_factor = fixed.Const(0.1225, shape=ASQ)
-                pb_scaled = Signal(shape=ASQ)
-                # TODO: pipeline this multiply through properly!
-                m.d.sync += pb_scaled.eq(pb_factor * last_pb)
 
                 # linearized frequency from LUT * pitch bend
                 calculated_freq = Signal(ASQ)
@@ -275,7 +337,10 @@ class MidiVoiceTracker(wiring.Component):
                             m.d.sync += self.o[n].freq_inc.eq(calculated_freq)
                             # optional mod wheel caps `velocity_mod` field.
                             if self.velocity_mod:
-                                with m.If(last_cc1 < self.o[n].velocity):
+                                with m.If(self.mpe_en):
+                                    m.d.sync += self.o[n].velocity_mod.eq(
+                                        mpe_press[n] + mpe_timbre[n])
+                                with m.Elif(last_cc1 < self.o[n].velocity):
                                     m.d.sync += self.o[n].velocity_mod.eq(last_cc1)
                                 with m.Else():
                                     m.d.sync += self.o[n].velocity_mod.eq(self.o[n].velocity)

--- a/gateware/src/top/polysyn/fw/src/main.rs
+++ b/gateware/src/top/polysyn/fw/src/main.rs
@@ -125,7 +125,11 @@ fn timer0_handler(app: &Mutex<RefCell<App>>) {
         app.synth.set_matrix_coefficient(2, 6, coeff_wet);
         app.synth.set_matrix_coefficient(3, 7, coeff_wet);
 
-        app.synth.set_midi_channel_filter(opts.misc.midi_ch.value.to_filter());
+        let mpe = opts.misc.mpe.value == Mpe::On;
+        app.synth.set_mpe(mpe);
+        app.synth.set_pitch_bend_range(opts.misc.pb_range.value.semitones());
+        app.synth.set_midi_channel_filter(
+            if mpe { None } else { opts.misc.midi_ch.value.to_filter() });
 
         // ADSR params
         app.synth.set_attack_rate(adsr_ui_to_rate(opts.adsr.attack.value));

--- a/gateware/src/top/polysyn/fw/src/options.rs
+++ b/gateware/src/top/polysyn/fw/src/options.rs
@@ -62,6 +62,41 @@ pub enum UsbHost {
 
 #[derive(Default, Clone, Copy, PartialEq, EnumIter, IntoStaticStr, Serialize, Deserialize)]
 #[strum(serialize_all = "kebab-case")]
+pub enum Mpe {
+    #[default]
+    Off,
+    On,
+}
+
+#[derive(Default, Clone, Copy, PartialEq, EnumIter, IntoStaticStr, Serialize, Deserialize)]
+pub enum PitchBendRange {
+    #[default]
+    #[strum(serialize = "2")]
+    St2,
+    #[strum(serialize = "12")]
+    St12,
+    #[strum(serialize = "24")]
+    St24,
+    #[strum(serialize = "48")]
+    St48,
+    #[strum(serialize = "96")]
+    St96,
+}
+
+impl PitchBendRange {
+    pub fn semitones(self) -> u8 {
+        match self {
+            PitchBendRange::St2  => 2,
+            PitchBendRange::St12 => 12,
+            PitchBendRange::St24 => 24,
+            PitchBendRange::St48 => 48,
+            PitchBendRange::St96 => 96,
+        }
+    }
+}
+
+#[derive(Default, Clone, Copy, PartialEq, EnumIter, IntoStaticStr, Serialize, Deserialize)]
+#[strum(serialize_all = "kebab-case")]
 pub enum UsbMidiSerialDebug {
     #[default]
     Off,
@@ -178,6 +213,10 @@ pub struct MiscOpts {
     pub cc_highlight: EnumOption<CcHighlight>,
     #[option]
     pub midi_ch: EnumOption<MidiChannel>,
+    #[option]
+    pub mpe: EnumOption<Mpe>,
+    #[option]
+    pub pb_range: EnumOption<PitchBendRange>,
     #[option]
     pub usb_host: EnumOption<UsbHost>,
     #[option]

--- a/gateware/src/top/polysyn/top.py
+++ b/gateware/src/top/polysyn/top.py
@@ -115,6 +115,8 @@ can also be used to control most of these through CCs as follows:
         MISC    touch-ctrl     -  enable/disable jacktouch input
         MISC    cc-highlight   -  highlight changed on CC input
         MISC    midi-ch        -  filter MIDI to specific channel (default: all)
+        MISC    mpe            -  MPE per-note pitch bend / pressure (ignores midi-ch)
+        MISC    pb-range       -  pitch bend range of the sending device (semitones)
         MISC    usb-host       -  enable USB host MIDI (disables TRS)
         MISC    serial-debug   -  dump MIDI data out serial port
         MISC    save-opts      -  save all options to flash
@@ -209,6 +211,9 @@ class PolySynth(wiring.Component):
     # Jack detection (directly from pmod hardware)
     jack: In(unsigned(8))
 
+    mpe_en: In(unsigned(1))
+    pb_scale: In(unsigned(8))
+
     voice_states: Out(midi.MidiVoice).array(N_VOICES)
     voice_cutoffs: Out(unsigned(8)).array(N_VOICES)
 
@@ -222,6 +227,11 @@ class PolySynth(wiring.Component):
 
         m.submodules.voice_tracker = voice_tracker = midi.MidiVoiceTracker(
             max_voices=n_voices, velocity_mod=True, zero_velocity_gate=False)
+
+        m.d.comb += [
+            voice_tracker.mpe_en.eq(self.mpe_en),
+            voice_tracker.pb_scale.eq(self.pb_scale),
+        ]
 
         # Connect MIDI stream -> voice tracker
         wiring.connect(m, wiring.flipped(self.i_midi), voice_tracker.i)
@@ -393,6 +403,12 @@ class SynthPeripheral(wiring.Component):
         """Channel filter. 0 = no filter, 1..16 = single MIDI channel."""
         value: csr.Field(csr.action.W, unsigned(5))
 
+    class PitchBendRange(csr.Register, access="w"):
+        value: csr.Field(csr.action.W, unsigned(8))
+
+    class Mpe(csr.Register, access="w"):
+        enable: csr.Field(csr.action.W, unsigned(1))
+
     def __init__(self, synth=None):
         self.synth = synth
         regs = csr.Builder(addr_width=7, data_width=8)
@@ -416,6 +432,8 @@ class SynthPeripheral(wiring.Component):
         self._wt_data       = regs.add("wt_data",       self.WavetableData(), offset=voices_csr_end + 0x30)
         self._lfo           = regs.add("lfo",           self.Lfo(),           offset=voices_csr_end + 0x34)
         self._midi_ch_filt  = regs.add("midi_ch_filter",self.MidiChannelFilter(), offset=voices_csr_end + 0x38)
+        self._mpe           = regs.add("mpe",           self.Mpe(),           offset=voices_csr_end + 0x3C)
+        self._pb_range      = regs.add("pb_range",      self.PitchBendRange(),offset=voices_csr_end + 0x40)
         self._bridge = csr.Bridge(regs.as_memory_map())
         super().__init__({
             "bus": In(csr.Signature(addr_width=regs.addr_width, data_width=regs.data_width)),
@@ -446,6 +464,11 @@ class SynthPeripheral(wiring.Component):
             m.d.sync += self.synth.sustain_level.eq(self._sustain_level.f.value.w_data)
         with m.If(self._release_rate.f.value.w_stb):
             m.d.sync += self.synth.release_rate.eq(self._release_rate.f.value.w_data)
+
+        with m.If(self._mpe.f.enable.w_stb):
+            m.d.sync += self.synth.mpe_en.eq(self._mpe.f.enable.w_data)
+        with m.If(self._pb_range.f.value.w_stb):
+            m.d.sync += self.synth.pb_scale.eq(self._pb_range.f.value.w_data)
 
         with m.If(self._lfo.f.value.w_stb):
             m.d.sync += self.synth.lfo.as_value().eq(self._lfo.f.value.w_data)


### PR DESCRIPTION
Adds experimental MIDI MPE support, tested on an Osmose CE 49. Mapping might only work properly on Osmose, as it's all I have :). Pressure and slide are summed, as osmose only has one vertical axis.

Might or might not be merged, this is just an experiment.

Pre-built bitstream:
[polysyn-1c9f0c2c-r5.tar.gz](https://github.com/user-attachments/files/31968348/polysyn-1c9f0c2c-r5.tar.gz)


To use, feed TRS or USB MIDI the same as normal `polysyn` (enabling USB host if needed) but:
- Set `MISC->mpe` to ON
- Set `MISC->pb_range` to the MPE pitch bend range of your controller (default 2 semitones)

For my favorite sound, I like the `strng` waveform, `drive=0.5` reso down to `0.12` and pump sustain up to `1.00` with release at `0.12`.